### PR TITLE
[CHK-5376] Updates flow id for payment booster and fastlane

### DIFF
--- a/Observer/ConfigObserver.php
+++ b/Observer/ConfigObserver.php
@@ -35,7 +35,6 @@ class Bold_CheckoutPaymentBooster_Observer_ConfigObserver
         $websiteId = Mage::app()->getWebsite($event->getWebsite())->getId();
         try {
             Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterFlow($websiteId);
-            Bold_CheckoutPaymentBooster_Service_Flow::processFastlaneFlow($websiteId);
         } catch (Exception $exception) {
             $this->addErrorMessage($exception->getMessage());
         }

--- a/Service/Flow.php
+++ b/Service/Flow.php
@@ -5,8 +5,7 @@
  */
 class Bold_CheckoutPaymentBooster_Service_Flow
 {
-    const DEFAULT_FLOW_ID = 'bold_booster_m1';
-    const FASTLANE_FLOW_ID = 'bold_booster_fastlane_m1';
+    const DEFAULT_FLOW_ID = 'bold-booster-m1';
     const STAGING_CONFIGURATION_GROUP = '/consumers/checkout-staging/configuration_group/{{shopDomain}}';
     const CONFIGURATION_GROUP = '/consumers/checkout/configuration_group/{{shopDomain}}';
 


### PR DESCRIPTION
* The flow id for Bold Booster was `bold_booster_m1` and the naming convention we are using is dashes so the flow id should be `bold-booster-m1`.
* We were giving Fastlane its own Flow which we shouldn't be and should be using the same flow id as bold booster.