### PR TITLE
CHK-4601: Render Express Pay Buttons on Cart Page

### DIFF
--- a/Block/Checkout/Expresspay.php
+++ b/Block/Checkout/Expresspay.php
@@ -11,7 +11,14 @@ class Bold_CheckoutPaymentBooster_Block_Checkout_Expresspay extends Mage_Core_Bl
         /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
         $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
 
-        return $config->isExpressPayEnabled($websiteId);
+        switch ($this->getAction()->getFullActionName()) {
+            case 'checkout_cart_index':
+                return $config->isExpressPayEnabledInCart($websiteId);
+            case 'checkout_onepage_index':
+                return $config->isExpressPayEnabled($websiteId);
+            default:
+                return false;
+        }
     }
 
     /**

--- a/Block/Checkout/Expresspay.php
+++ b/Block/Checkout/Expresspay.php
@@ -21,6 +21,11 @@ class Bold_CheckoutPaymentBooster_Block_Checkout_Expresspay extends Mage_Core_Bl
         }
     }
 
+    public function isCheckoutActive()
+    {
+        return $this->getAction()->getFullActionName() === 'checkout_onepage_index';
+    }
+
     /**
      * @return string
      */

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -12,6 +12,7 @@ class Bold_CheckoutPaymentBooster_Model_Config
     const PATH_IS_PAYMENT_BOOSTER_ENABLED = 'checkout/bold_checkout_payment_booster/is_payment_booster_enabled';
     const PATH_IS_FASTLANE_ENABLED = 'checkout/bold_checkout_payment_booster/is_fastlane_enabled';
     const PATH_IS_EXPRESS_PAY_ENABLED = 'checkout/bold_checkout_payment_booster/is_expresspay_enabled';
+    const PATH_IS_EXPRESS_PAY_ENABLED_CART = 'checkout/bold_checkout_payment_booster/is_expresspay_enabled_cart';
     const PATH_API_TOKEN = 'checkout/bold_checkout_payment_booster/api_token';
     const PATH_SHARED_SECRET = 'checkout/bold_checkout_payment_booster/shared_secret';
     const PATH_SHOP_ID = 'checkout/bold_checkout_payment_booster/shop_id';
@@ -60,6 +61,18 @@ class Bold_CheckoutPaymentBooster_Model_Config
     public function isExpressPayEnabled($websiteId)
     {
         return (bool)Mage::app()->getWebsite($websiteId)->getConfig(self::PATH_IS_EXPRESS_PAY_ENABLED)
+            && Mage::helper('core')->isModuleOutputEnabled('Bold_CheckoutPaymentBooster');
+    }
+
+    /**
+     * Check if Express Pay is enabled in the Cart.
+     *
+     * @param int $websiteId
+     * @return bool
+     */
+    public function isExpressPayEnabledInCart($websiteId)
+    {
+        return (bool)Mage::app()->getWebsite($websiteId)->getConfig(self::PATH_IS_EXPRESS_PAY_ENABLED_CART)
             && Mage::helper('core')->isModuleOutputEnabled('Bold_CheckoutPaymentBooster');
     }
 

--- a/Observer/CartObserver.php
+++ b/Observer/CartObserver.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Observer for `controller_action_predispatch_checkout_cart_index` event
+ */
+class Bold_CheckoutPaymentBooster_Observer_CartObserver
+{
+    /**
+     * Initialize Bold order
+     *
+     * @param Varien_Event_Observer $event
+     * @return void
+     * @throws Exception
+     */
+    public function execute(Varien_Event_Observer $event)
+    {
+        /** @var Mage_Sales_Model_Quote $quote */
+        $quote = Mage::getModel('checkout/cart')->getQuote();
+
+        try {
+            Bold_CheckoutPaymentBooster_Service_Bold::initBoldCheckoutData($quote);
+
+            $publicOrderId = Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId();
+
+            if ($publicOrderId === null) {
+                return;
+            }
+        } catch (Exception $exception) {
+            Mage::log($exception->getMessage(), Zend_Log::CRIT);
+        }
+    }
+}

--- a/Observer/CartObserver.php
+++ b/Observer/CartObserver.php
@@ -14,6 +14,13 @@ class Bold_CheckoutPaymentBooster_Observer_CartObserver
      */
     public function execute(Varien_Event_Observer $event)
     {
+        if (
+            !Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE)
+                ->isExpressPayEnabledInCart(Mage::app()->getStore()->getWebsiteId())
+        ) {
+            return;
+        }
+
         /** @var Mage_Sales_Model_Quote $quote */
         $quote = Mage::getModel('checkout/cart')->getQuote();
 

--- a/Observer/CartObserver.php
+++ b/Observer/CartObserver.php
@@ -28,5 +28,7 @@ class Bold_CheckoutPaymentBooster_Observer_CartObserver
         } catch (Exception $exception) {
             Mage::log($exception->getMessage(), Zend_Log::CRIT);
         }
+
+        Mage::getSingleton('checkout/session')->setCartWasUpdated(false);
     }
 }

--- a/design/frontend/base/default/layout/bold/checkout.xml
+++ b/design/frontend/base/default/layout/bold/checkout.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0"?>
 <layout version="0.1.0">
+    <checkout_cart_index>
+        <reference name="head">
+            <action method="addItem" ifconfig="checkout/bold_checkout_payment_booster/is_expresspay_enabled_cart">
+                <type>skin_js</type>
+                <name>js/bold/checkout_payment_booster/expresspay.js</name>
+            </action>
+        </reference>
+        <reference name="checkout.cart.methods">
+            <block
+                    type="bold_checkout_payment_booster/checkout_expresspay"
+                    name="bold_booster_expresspay"
+                    as="bold.booster.expresspay"
+                    template="bold/checkout_payment_booster/checkout/expresspay.phtml"
+                    after="-"
+                    ifconfig="checkout/bold_checkout_payment_booster/is_expresspay_enabled_cart"
+            />
+        </reference>
+    </checkout_cart_index>
     <checkout_onepage_index>
         <reference name="head">
             <action method="addItem" ifconfig="checkout/bold_checkout_payment_booster/is_expresspay_enabled">

--- a/design/frontend/base/default/template/bold/checkout_payment_booster/checkout/expresspay.phtml
+++ b/design/frontend/base/default/template/bold/checkout_payment_booster/checkout/expresspay.phtml
@@ -9,9 +9,11 @@ endif;
 $quote = $this->getQuote();
 ?>
 <section id="express-pay-container">
+    <?php if ($this->isCheckoutActive()): ?>
     <header class="page-title">
         <h1><?php echo $this->__('Express Checkout') ?></h1>
     </header>
+    <?php endif; ?>
 </section>
 
 <script type="text/javascript">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -39,6 +39,14 @@
     </global>
     <frontend>
         <events>
+            <controller_action_predispatch_checkout_cart_index>
+                <observers>
+                    <initialize_bold_order>
+                        <class>Bold_CheckoutPaymentBooster_Observer_CartObserver</class>
+                        <method>execute</method>
+                    </initialize_bold_order>
+                </observers>
+            </controller_action_predispatch_checkout_cart_index>
             <controller_action_predispatch_checkout_onepage_index>
                 <observers>
                     <init_bold_order>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -127,6 +127,7 @@
                 <is_payment_booster_enabled>0</is_payment_booster_enabled>
                 <is_fastlane_enabled>0</is_fastlane_enabled>
                 <is_expresspay_enabled>0</is_expresspay_enabled>
+                <is_expresspay_enabled_cart>0</is_expresspay_enabled_cart>
             </bold_checkout_payment_booster>
             <bold_checkout_payment_booster_advanced>
                 <api_url>https://api.boldcommerce.com/</api_url>

--- a/etc/system.xml
+++ b/etc/system.xml
@@ -54,6 +54,18 @@
                                 <is_payment_booster_enabled>1</is_payment_booster_enabled>
                             </depends>
                         </is_expresspay_enabled>
+                        <is_expresspay_enabled_cart translate="label">
+                            <label>Enable Express Pay in Cart</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>17</sort_order>
+                            <show_in_default>0</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <comment><![CDATA[Show payment buttons below Cart]]></comment>
+                            <depends>
+                                <is_payment_booster_enabled>1</is_payment_booster_enabled>
+                            </depends>
+                        </is_expresspay_enabled_cart>
                         <api_token>
                             <label>API Token</label>
                             <frontend_type>obscure</frontend_type>


### PR DESCRIPTION
Resolves [CHK-4601](https://boldapps.atlassian.net/browse/CHK-4601)
Relates to [CHK-6325](https://boldapps.atlassian.net/browse/CHK-6325)

<img width="1239" alt="Screenshot of Express Pay buttons on Magento 1 Cart page" src="https://github.com/user-attachments/assets/77435ff6-6265-4c53-a448-f98c499ebb7c">


[CHK-4601]: https://boldapps.atlassian.net/browse/CHK-4601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CHK-6325]: https://boldapps.atlassian.net/browse/CHK-6325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ