### PR TITLE
CHK-6578 Autodetect local development urls

### DIFF
--- a/Service/BoldClient.php
+++ b/Service/BoldClient.php
@@ -157,8 +157,29 @@ class Bold_CheckoutPaymentBooster_Service_BoldClient
     {
         /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
         $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
-        return $config->getApiUrl($websiteId)
+        $url = $config->getApiUrl($websiteId)
             . '/'
             . ltrim(str_replace('{{shopId}}', $shopId, $path), '/');
+
+        if (strpos($url, 'sidekick') !== false && strpos($url, '.bold.ninja') !== false) {
+            $parseApiUrl = parse_url($url);
+            $scheme = $parseApiUrl['scheme'];
+            $host = $parseApiUrl['host'];
+            $path = ltrim($parseApiUrl['path'],'/');
+            $pathParts = explode('/', $path);
+            $newPath = "$scheme://$host";
+
+            foreach($pathParts as $part) {
+                if (strpos($part, '.bold.ninja') !== false) {
+                    $newPath = $newPath.'/'.'sidekick-'.$part;
+                } else {
+                    $newPath = $newPath.'/'.$part;
+                }
+            }
+
+            $url = $newPath;
+        }
+
+        return $url;
     }
 }

--- a/Service/ShopInfo.php
+++ b/Service/ShopInfo.php
@@ -46,6 +46,13 @@ class Bold_CheckoutPaymentBooster_Service_ShopInfo
         ];
         $url = $config->getApiUrl($websiteId) . self::SHOP_INFO_URI;
 
+        if (strpos($url, 'bold.ninja') !== false) {
+            $parseApiUrl = parse_url($url);
+            $scheme = $parseApiUrl['scheme'];
+            $host = $parseApiUrl['host'];
+            $url = $scheme . '://' . $host .self::SHOP_INFO_URI;
+        }
+
         $shopInfo = json_decode(
             Bold_CheckoutPaymentBooster_Service_Client_Http::call(
                 'GET',


### PR DESCRIPTION
Allows developers to integrate the module with their local instances of Checkout and Sidekick.

Resolves [CHK-6578](https://boldapps.atlassian.net/browse/CHK-6578)

[CHK-6578]: https://boldapps.atlassian.net/browse/CHK-6578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ