### PR TITLE
CHK-6471 update checkout order after shipping method change

### DIFF
--- a/Observer/CheckoutObserver.php
+++ b/Observer/CheckoutObserver.php
@@ -92,6 +92,28 @@ class Bold_CheckoutPaymentBooster_Observer_CheckoutObserver
         }
     }
 
+    public function updateOrderShippingMethod(Varien_Event_Observer $event)
+    {
+        $publicOrderId = Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId();
+        if (!$publicOrderId) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if ($request->getParam('source') === 'expresspay') {
+            return;
+        }
+
+        /** @var Mage_Sales_Model_Quote $quote */
+        $quote = $event->getQuote();
+        try {
+            Bold_CheckoutPaymentBooster_Service_Order_Hydrate::hydrate($quote);
+        } catch (Mage_Core_Exception $e) {
+            Mage::log($e->getMessage(), Zend_Log::CRIT);
+            Mage::throwException(Mage::helper('core')->__('Bold update failed.'));
+        }
+    }
+
     /**
      * Add Bold transaction data to order payment.
      *

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -72,6 +72,14 @@
                     </authorize_bold_payment>
                 </observers>
             </checkout_type_onepage_save_order>
+            <checkout_controller_onepage_save_shipping_method>
+                <observers>
+                    <update_bold_shipping>
+                        <class>Bold_CheckoutPaymentBooster_Observer_CheckoutObserver</class>
+                        <method>updateOrderShippingMethod</method>
+                    </update_bold_shipping>
+                </observers>
+            </checkout_controller_onepage_save_shipping_method>
         </events>
         <routers>
             <checkoutpaymentbooster>


### PR DESCRIPTION
- The Checkout order was not being updated after the the initial shipping method selection. Subsequent changes to this selection were not propagated to Checkout, resulting in incorrect order totals. While this did not impact the ability to complete Checkout, it became an issue when attempting to capture payment for the order. If the order value was greater than the payment-authorized amount (by an amount determined by the payment gateway), payment capture could fail, with no way to recover the full amount of the order.
- A new event handler allows the Bold Booster module to listen for shipping method changes and update Checkout accordingly.
- Tested locally using an M1 shop with multiple shipping options, with Bold Booster installed.

Fixes [CHK-6471](https://boldapps.atlassian.net/browse/CHK-6471)

[CHK-6471]: https://boldapps.atlassian.net/browse/CHK-6471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ