### PR TITLE
CHK-6805 Bump version number 2.0.1

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Bold_CheckoutPaymentBooster>
-            <version>2.0.0</version>
+            <version>2.0.1</version>
         </Bold_CheckoutPaymentBooster>
     </modules>
     <global>


### PR DESCRIPTION
Resolves [CHK-6805](https://boldapps.atlassian.net/browse/CHK-6805)

[CHK-6805]: https://boldapps.atlassian.net/browse/CHK-6805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ