### PR TITLE
CHK-6850 Remove hydrate order calls

### DIFF
--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -6,36 +6,6 @@
 class Bold_CheckoutPaymentBooster_IndexController extends Mage_Core_Controller_Front_Action
 {
     /**
-     * Hydrate order data to Bold order action.
-     *
-     * @return void
-     */
-    public function hydrateOrderDataAction()
-    {
-        if (!$this->_validateFormKey()) {
-            return;
-        }
-        $post = $this->getRequest()->getPost();
-        unset($post['form_key']);
-        if (empty($post)) {
-            Mage::throwException('No data provided.');
-        }
-        $quote = Mage::getSingleton('checkout/session')->getQuote();
-        if (!$quote->getId()) {
-            Mage::throwException('No quote found.');
-        }
-        if (isset($post['address_id']) && $quote->getCustomer()->getId()) {
-            Bold_CheckoutPaymentBooster_Service_Order_Hydrate::hydrate($quote);
-            return;
-        }
-        $post['street'] = $post['street2']
-            ? $post['street1'] . "\n" . $post['street2']
-            : $post['street1'];
-        $this->addAddressDataToQuote($quote, $post);
-        Bold_CheckoutPaymentBooster_Service_Order_Hydrate::hydrate($quote);
-    }
-
-    /**
      * Get cart data action.
      *
      * @return void

--- a/design/frontend/base/default/template/bold/checkout_payment_booster/payment/form/base.phtml
+++ b/design/frontend/base/default/template/bold/checkout_payment_booster/payment/form/base.phtml
@@ -87,8 +87,6 @@
             if (!this.isAvailable) {
                 return false;
             }
-            this.hydrateOrderData();
-            this.subscribeToBillingAddressFieldsChanges();
             if (!this.isFastlaneAvailable) {
                 return;
             }
@@ -312,7 +310,6 @@
                     element.value = magentoAddress[field];
                 }
             });
-            this.hydrateOrderData();
         },
         /**
          * Convert Fastlane address to Magento address.
@@ -513,24 +510,6 @@
             });
         },
         /**
-         * Subscribe to fields changes for order hydration.
-         *
-         * @returns {void}
-         */
-        subscribeToBillingAddressFieldsChanges: function () {
-            Object.values(this.orderDataFieldMapper).each(function (selector) {
-                let field = $(selector);
-                if (field) {
-                    field.observe('change', () => {
-                        setTimeout(() => {
-                            this.hydrateOrderData();
-                        }, 500);
-                    });
-                }
-            }.bind(this));
-        }
-        ,
-        /**
          * Update order data payload for order hydration call.
          *
          * @returns {void}
@@ -585,48 +564,6 @@
                 }
             }
             return isChanged;
-        },
-        /**
-         * Hydrate Bold order.
-         */
-        hydrateOrderData: function () {
-            if (Ajax.activeRequestCount > 0) {
-                this.hydrateOrderData.bind(this).delay(0.1);
-                return;
-            }
-            this.updateOrderDataPayload();
-            if (!this.isPayloadValid()) {
-                return;
-            }
-            if (!this.isPayloadChanged()) {
-                return;
-            }
-            new Ajax.Request('/checkoutpaymentbooster/index/hydrateOrderData', {
-                method: 'post',
-                parameters: Object.assign(
-                    this.orderPayload,
-                    {
-                        form_key: '<?php echo Mage::getSingleton('core/session')->getFormKey() ?>'
-                    }
-                ),
-                onSuccess: function () {
-                    if (this.orderPayload.region_id) {
-                        const region = billingRegionUpdater.regions[this.orderPayload.country_id][this.orderPayload.region_id] || null;
-                        if (region) {
-                            this.orderPayload.region = region.code;
-                        }
-                    }
-                    this.synchronizedOrderData = Object.assign({}, this.orderPayload);
-                }.bind(this),
-                onFailure: function () {
-                    if (window.bold.fastlanePaymentMethod) {
-                        window.bold.fastlanePaymentMethod.hidePaymentMethod();
-                    }
-                    checkout.setLoadWaiting(false);
-                    this.synchronizedOrderData = {};
-                    console.error('Failed to sync order data');
-                }.bind(this),
-            });
         },
         /**
          * Get email field.


### PR DESCRIPTION
- The hydrateOrderData calls have been broken for an unknown amount of time.
- These calls appeared to succeed, but inspection of their response payload revealed a stack trace resulting from a server-side exception being thrown.
- The trace indicated that the expected call to sidekick's hydrate endpoint was never occuring.
- All other aspects of the M1 Bold Booster appeared to still work correctly, including order completion, payment capture and the order update in Checkout.
- Removed the `hydrateOrderData` functions from the Bold Booster frontend and backend code.
- Removed `subscribeToBillingAddressUpdate` because it only called `hydrateOrderData`.
- Tested with Bold Booster using PPCP (acdc and PayPal button) and Fastlane.

Fixes [CHK-6850](https://boldapps.atlassian.net/browse/CHK-6850)

[CHK-6850]: https://boldapps.atlassian.net/browse/CHK-6850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ