### PR TITLE
CHK-6954: Remove Requirement on Region Name, Region Identifier and Postal Code During Sidekick Order Hydration

### DIFF
--- a/Service/Order/Hydrate/ExtractData.php
+++ b/Service/Order/Hydrate/ExtractData.php
@@ -21,8 +21,6 @@ class Bold_CheckoutPaymentBooster_Service_Order_Hydrate_ExtractData
         'lastname',
         'telephone',
         'postcode',
-        'region',
-        'region_id',
     ];
 
     private static $discounts = [];

--- a/Service/Order/Hydrate/ExtractData.php
+++ b/Service/Order/Hydrate/ExtractData.php
@@ -20,7 +20,6 @@ class Bold_CheckoutPaymentBooster_Service_Order_Hydrate_ExtractData
         'street',
         'lastname',
         'telephone',
-        'postcode',
     ];
 
     private static $discounts = [];


### PR DESCRIPTION
Fixes billing address incorrectly replacing shipping address in Checkout for international orders.

### Before
<img width="291" alt="Screenshot of order in Bold Checkout with incorrect shipping address" src="https://github.com/user-attachments/assets/c953450b-ff7a-4460-b301-1ffd28775a66" />

### After
<img width="290.75" alt="Screenshot of order in Bold Checkout with correct shipping address" src="https://github.com/user-attachments/assets/55039edf-1c4e-4e14-afc1-ff2deb69998f" />

Fixes [CHK-6954](https://boldapps.atlassian.net/browse/CHK-6954)

[CHK-6954]: https://boldapps.atlassian.net/browse/CHK-6954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ