### PR TITLE
CHK-6926: Fix PayPal Buttons Rendered on Top of Product Images on Product Detail Page

### DIFF
--- a/skin/frontend/base/default/css/bold/checkout_payment_booster/expresspay.css
+++ b/skin/frontend/base/default/css/bold/checkout_payment_booster/expresspay.css
@@ -10,4 +10,8 @@
 
 #product-detail-express-pay-container {
     clear: left;
+
+    .paypal-buttons > iframe.component-frame {
+        z-index: auto;
+    }
 }


### PR DESCRIPTION
<img width="305" alt="Screenshot of product detail page with product image magnified" src="https://github.com/user-attachments/assets/f1730c11-8260-410e-b0d7-ddfe93743e3c" />

Fixes [CHK-6926](https://boldapps.atlassian.net/browse/CHK-6926)

[CHK-6926]: https://boldapps.atlassian.net/browse/CHK-6926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ