### PR TITLE
CHK-6711: Use Separate Bold Checkout Flow ID for Digital Wallet Orders on Product Detail Page

### DIFF
--- a/Observer/ConfigObserver.php
+++ b/Observer/ConfigObserver.php
@@ -35,6 +35,7 @@ class Bold_CheckoutPaymentBooster_Observer_ConfigObserver
         $websiteId = Mage::app()->getWebsite($event->getWebsite())->getId();
         try {
             Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterFlow($websiteId);
+            Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterPdpFlow($websiteId);
         } catch (Exception $exception) {
             $this->addErrorMessage($exception->getMessage());
         }

--- a/Observer/PredispatchObserver.php
+++ b/Observer/PredispatchObserver.php
@@ -63,8 +63,19 @@ class Bold_CheckoutPaymentBooster_Observer_PredispatchObserver
             return;
         }
 
+        $flowId = Bold_CheckoutPaymentBooster_Service_Flow::DEFAULT_FLOW_ID;
+        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        $isExpressPayEnabledOnProductPage = $config->isExpressPayEnabledOnProductPage(
+            $quote->getStore()->getWebsiteId()
+        );
+
+        if ($actionName === 'catalog_product_view' && $isExpressPayEnabledOnProductPage) {
+            $flowId = Bold_CheckoutPaymentBooster_Service_Flow::PDP_FLOW_ID;
+        }
+
         try {
-            Bold_CheckoutPaymentBooster_Service_Bold::initBoldCheckoutData($quote);
+            Bold_CheckoutPaymentBooster_Service_Bold::initBoldCheckoutData($quote, $flowId);
 
             $publicOrderId = Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId();
 

--- a/Service/Bold.php
+++ b/Service/Bold.php
@@ -11,8 +11,10 @@ class Bold_CheckoutPaymentBooster_Service_Bold
      * @param Mage_Sales_Model_Quote $quote
      * @throws Mage_Core_Exception
      */
-    public static function initBoldCheckoutData(Mage_Sales_Model_Quote $quote)
-    {
+    public static function initBoldCheckoutData(
+        Mage_Sales_Model_Quote $quote,
+        $flowId = Bold_CheckoutPaymentBooster_Service_Flow::DEFAULT_FLOW_ID
+    ) {
         if (!self::isAvailable()) {
             return;
         }
@@ -29,7 +31,7 @@ class Bold_CheckoutPaymentBooster_Service_Bold
                 return;
             }
         }
-        $checkoutData = Bold_CheckoutPaymentBooster_Service_Order_Init::init($quote);
+        $checkoutData = Bold_CheckoutPaymentBooster_Service_Order_Init::init($quote, $flowId);
         /** @var Mage_Checkout_Model_Session $checkoutSession */
         $checkoutSession = Mage::getSingleton('checkout/session');
         $checkoutSession->setBoldCheckoutData($checkoutData);

--- a/Service/Flow.php
+++ b/Service/Flow.php
@@ -6,6 +6,7 @@
 class Bold_CheckoutPaymentBooster_Service_Flow
 {
     const DEFAULT_FLOW_ID = 'bold-booster-m1';
+    const PDP_FLOW_ID = 'bold-booster-pdp-m1';
     const STAGING_CONFIGURATION_GROUP = '/consumers/checkout-staging/configuration_group/{{shopDomain}}';
     const CONFIGURATION_GROUP = '/consumers/checkout/configuration_group/{{shopDomain}}';
 
@@ -131,6 +132,40 @@ class Bold_CheckoutPaymentBooster_Service_Flow
             [
                 'flow_id' => self::DEFAULT_FLOW_ID,
                 'flow_name' => 'Bold Booster for PayPal',
+                'flow_type' => 'custom',
+            ]
+        );
+    }
+
+    /**
+     * Create|update Payment Booster PDP flow for given website.
+     *
+     * @param int $websiteId
+     * @return void
+     */
+    public static function processPaymentBoosterPdpFlow($websiteId)
+    {
+        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        $isExpressPayEnabledOnProductPage = $config->isExpressPayEnabledOnProductPage($websiteId);
+
+        if (!$isExpressPayEnabledOnProductPage) {
+            return;
+        }
+
+        $flows = self::getList($websiteId);
+
+        foreach ($flows as $flow) {
+            if ($flow->flow_id === self::PDP_FLOW_ID) {
+                return;
+            }
+        }
+
+        self::createFlow(
+            $websiteId,
+            [
+                'flow_id' => self::PDP_FLOW_ID,
+                'flow_name' => 'Bold Booster for PayPal on Product Detail Page',
                 'flow_type' => 'custom',
             ]
         );

--- a/Service/Order/Init.php
+++ b/Service/Order/Init.php
@@ -14,10 +14,12 @@ class Bold_CheckoutPaymentBooster_Service_Order_Init
      * @return stdClass
      * @throws Mage_Core_Exception
      */
-    public static function init(Mage_Sales_Model_Quote $quote)
-    {
+    public static function init(
+        Mage_Sales_Model_Quote $quote,
+        $flowId = Bold_CheckoutPaymentBooster_Service_Flow::DEFAULT_FLOW_ID
+    ) {
         $body = [
-            'flow_id' => Bold_CheckoutPaymentBooster_Service_Flow::DEFAULT_FLOW_ID,
+            'flow_id' => $flowId,
             'order_type' => 'simple_order',
             'cart_id' => $quote->getId() ?: '',
         ];


### PR DESCRIPTION
<img width="289.25" alt="Screenshot of Bold Checkout order showing new Flow ID" src="https://github.com/user-attachments/assets/f30da1f8-8e55-4c98-a4ce-8c0eea801886" />

Resolves [CHK-6711](https://boldapps.atlassian.net/browse/CHK-6711)

[CHK-6711]: https://boldapps.atlassian.net/browse/CHK-6711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ