### PR TITLE
CHK-6989: Render Multiple Sets of Digital Wallet Payment Buttons on the Same Page

### DIFF
--- a/Block/Checkout/Expresspay.php
+++ b/Block/Checkout/Expresspay.php
@@ -33,11 +33,6 @@ class Bold_CheckoutPaymentBooster_Block_Checkout_Expresspay extends Mage_Core_Bl
         return $this->getAction()->getFullActionName() === 'checkout_onepage_index';
     }
 
-    public function isProductPageActive()
-    {
-        return $this->getAction()->getFullActionName() === 'catalog_product_view';
-    }
-
     /**
      * @return string
      */

--- a/Block/Checkout/Expresspay.php
+++ b/Block/Checkout/Expresspay.php
@@ -16,10 +16,7 @@ class Bold_CheckoutPaymentBooster_Block_Checkout_Expresspay extends Mage_Core_Bl
 
         switch ($this->getBlockAlias()) {
             case 'cart_sidebar.bold.booster.expresspay':
-                return $this->getAction()->getFullActionName() !== 'checkout_cart_index'
-                    && $this->getAction()->getFullActionName() !== 'catalog_product_view'
-                    && $this->getAction()->getFullActionName() !== 'checkout_onepage_index'
-                    && $config->isExpressPayEnabledInMiniCart($websiteId);
+                return $config->isExpressPayEnabledInMiniCart($websiteId);
             case 'product.detail.bold.booster.expresspay':
                 return $config->isExpressPayEnabledOnProductPage($websiteId);
             case 'cart.bold.booster.expresspay':

--- a/design/frontend/base/default/template/bold/checkout_payment_booster/checkout/expresspay.phtml
+++ b/design/frontend/base/default/template/bold/checkout_payment_booster/checkout/expresspay.phtml
@@ -50,8 +50,6 @@ $quote = $this->getQuote();
         getCartItemsUrl: '<?php echo $this->escapeUrl($this->getUrl('checkoutpaymentbooster/index/getCartItems')) ?>',
     };
 
-    ExpressPay(expressPayConfig, <?php var_export($this->isProductPageActive()) ?>).then(
-        async expressPay => await expressPay.render()
-    );
+    ExpressPay(expressPayConfig).then(async expressPay => await expressPay.render());
 })();
 </script>

--- a/skin/frontend/base/default/js/bold/checkout_payment_booster/expresspay.js
+++ b/skin/frontend/base/default/js/bold/checkout_payment_booster/expresspay.js
@@ -2,7 +2,6 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
     'use strict';
 
     let errorRendered = false;
-    let boldPayments;
     let addToCartPromise;
     let cartTotals;
     let cartItems;
@@ -960,6 +959,10 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
 
         const isCheckoutActive = window.location.pathname === '/checkout/onepage/';
 
+        if (window.hasOwnProperty('boldPayments')) {
+            return;
+        }
+
         if (
             (isCheckoutActive && !config.isFastlaneEnabled)
             || !window.hasOwnProperty('bold')
@@ -1139,7 +1142,7 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
             }
         }
 
-        boldPayments = new window.bold.Payments(sdkConfiguration);
+        window.boldPayments = new window.bold.Payments(sdkConfiguration);
     };
 
     /**
@@ -1173,7 +1176,7 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
          * @returns {Promise<void>}
          */
         render: async () => {
-            await boldPayments.renderWalletPayments(
+            await window.boldPayments.renderWalletPayments(
                 config.paymentsContainer,
                 {
                     allowedCountries: config.allowedCountries,

--- a/skin/frontend/base/default/js/bold/checkout_payment_booster/expresspay.js
+++ b/skin/frontend/base/default/js/bold/checkout_payment_booster/expresspay.js
@@ -1,6 +1,7 @@
-const ExpressPay = async (config, isProductPageActive) => (async (config, isProductPageActive) => {
+const ExpressPay = async config => (async config => {
     'use strict';
 
+    let isProductPageActive = false;
     let errorRendered = false;
     let addToCartPromise;
     let cartTotals;
@@ -283,7 +284,7 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
         const quoteItems = cartItems ?? config.quoteItems;
         const requiredOrderData = {};
 
-        if (isProductPageActive && Number(orderTotal) === 0) {
+        if (Number(orderTotal) === 0) {
             orderTotal = config.productPrice;
         }
 
@@ -999,6 +1000,8 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
                  * @throws Error
                  */
                 onClickPaymentOrder: async (paymentType, paymentPayload) => {
+                    isProductPageActive = paymentPayload.containerId.includes('product-detail');
+
                     if (!isProductPageActive) {
                         return;
                     }
@@ -1154,7 +1157,7 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
             config.paymentsContainer ?? defaultConfig.paymentsContainer
         );
 
-        if (!isProductPageActive && validationErrors.length > 0) {
+        if (config.pageSource !== 'product-details' && validationErrors.length > 0) {
             if (expressPayContainer !== null) {
                 expressPayContainer.style.display = 'none';
             }
@@ -1192,4 +1195,4 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
             );
         }
     };
-})(config, isProductPageActive);
+})(config);

--- a/skin/frontend/base/default/js/bold/checkout_payment_booster/expresspay.js
+++ b/skin/frontend/base/default/js/bold/checkout_payment_booster/expresspay.js
@@ -1148,7 +1148,7 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
     /**
      * @returns {Promise<void>}
      */
-    const initialize = async () => {
+    const initialize = () => {
         const validationErrors = validateConfig(config);
         const expressPayContainer = document.getElementById(
             config.paymentsContainer ?? defaultConfig.paymentsContainer
@@ -1166,7 +1166,11 @@ const ExpressPay = async (config, isProductPageActive) => (async (config, isProd
 
         config = {...defaultConfig, ...config};
 
-        await initializePaymentsSdk();
+        if (!window.hasOwnProperty('expressPayInitializationPromise')) {
+            window.expressPayInitializationPromise = initializePaymentsSdk();
+        }
+
+        return window.expressPayInitializationPromise;
     };
 
     await initialize();


### PR DESCRIPTION
<img width="304.5" alt="Screenshot of Digital Wallet buttons rendering simultaneously in the mini cart and on the product detail page" src="https://github.com/user-attachments/assets/822bb40e-0484-47d1-98d8-c5ff5ddd804c" />

Fixes [CHK-6989](https://boldapps.atlassian.net/browse/CHK-6989)

[CHK-6989]: https://boldapps.atlassian.net/browse/CHK-6989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ