### PR TITLE
CHK-6712: Use Separate Bold Checkout Flow ID for Digital Wallet Orders on Cart Page 

### DIFF
--- a/Observer/ConfigObserver.php
+++ b/Observer/ConfigObserver.php
@@ -36,6 +36,7 @@ class Bold_CheckoutPaymentBooster_Observer_ConfigObserver
         try {
             Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterFlow($websiteId);
             Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterPdpFlow($websiteId);
+            Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterCartFlow($websiteId);
         } catch (Exception $exception) {
             $this->addErrorMessage($exception->getMessage());
         }

--- a/Observer/PredispatchObserver.php
+++ b/Observer/PredispatchObserver.php
@@ -69,9 +69,14 @@ class Bold_CheckoutPaymentBooster_Observer_PredispatchObserver
         $isExpressPayEnabledOnProductPage = $config->isExpressPayEnabledOnProductPage(
             $quote->getStore()->getWebsiteId()
         );
+        $isExpressPayEnabledInCart = $config->isExpressPayEnabledInCart($quote->getStore()->getWebsiteId());
 
         if ($actionName === 'catalog_product_view' && $isExpressPayEnabledOnProductPage) {
             $flowId = Bold_CheckoutPaymentBooster_Service_Flow::PDP_FLOW_ID;
+        }
+
+        if ($actionName === 'checkout_cart_index' && $isExpressPayEnabledInCart) {
+            $flowId = Bold_CheckoutPaymentBooster_Service_Flow::CART_FLOW_ID;
         }
 
         try {

--- a/Service/Flow.php
+++ b/Service/Flow.php
@@ -7,6 +7,7 @@ class Bold_CheckoutPaymentBooster_Service_Flow
 {
     const DEFAULT_FLOW_ID = 'bold-booster-m1';
     const PDP_FLOW_ID = 'bold-booster-pdp-m1';
+    const CART_FLOW_ID = 'bold-booster-cart-m1';
     const STAGING_CONFIGURATION_GROUP = '/consumers/checkout-staging/configuration_group/{{shopDomain}}';
     const CONFIGURATION_GROUP = '/consumers/checkout/configuration_group/{{shopDomain}}';
 
@@ -166,6 +167,40 @@ class Bold_CheckoutPaymentBooster_Service_Flow
             [
                 'flow_id' => self::PDP_FLOW_ID,
                 'flow_name' => 'Bold Booster for PayPal on Product Detail Page',
+                'flow_type' => 'custom',
+            ]
+        );
+    }
+
+    /**
+     * Create|update Payment Booster cart flow for given website.
+     *
+     * @param int $websiteId
+     * @return void
+     */
+    public static function processPaymentBoosterCartFlow($websiteId)
+    {
+        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        $isExpressPayEnabledInCart = $config->isExpressPayEnabledInCart($websiteId);
+
+        if (!$isExpressPayEnabledInCart) {
+            return;
+        }
+
+        $flows = self::getList($websiteId);
+
+        foreach ($flows as $flow) {
+            if ($flow->flow_id === self::CART_FLOW_ID) {
+                return;
+            }
+        }
+
+        self::createFlow(
+            $websiteId,
+            [
+                'flow_id' => self::CART_FLOW_ID,
+                'flow_name' => 'Bold Booster for PayPal on Cart Page',
                 'flow_type' => 'custom',
             ]
         );


### PR DESCRIPTION
<img width="285" alt="Screenshot of Bold Checkout order with updated flow ID" src="https://github.com/user-attachments/assets/ca210654-707f-48f5-8ca6-253b1fa12043" />

Resolves [CHK-6712](https://boldapps.atlassian.net/browse/CHK-6712)

[CHK-6712]: https://boldapps.atlassian.net/browse/CHK-6712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ