### PR TITLE
CHK-7037: Remove Disused Checkout Shipping Save Event Observer

### DIFF
--- a/Observer/CheckoutObserver.php
+++ b/Observer/CheckoutObserver.php
@@ -70,28 +70,6 @@ class Bold_CheckoutPaymentBooster_Observer_CheckoutObserver
         }
     }
 
-    public function updateOrderShippingMethod(Varien_Event_Observer $event)
-    {
-        $publicOrderId = Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId();
-        if (!$publicOrderId) {
-            return;
-        }
-
-        $request = $event->getRequest();
-        if ($request->getParam('source') === 'expresspay') {
-            return;
-        }
-
-        /** @var Mage_Sales_Model_Quote $quote */
-        $quote = $event->getQuote();
-        try {
-            Bold_CheckoutPaymentBooster_Service_Order_Hydrate::hydrate($quote);
-        } catch (Mage_Core_Exception $e) {
-            Mage::log($e->getMessage(), Zend_Log::CRIT);
-            Mage::throwException(Mage::helper('core')->__('Bold update failed.'));
-        }
-    }
-
     /**
      * Add Bold transaction data to order payment.
      *

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -87,14 +87,6 @@
                     </authorize_bold_payment>
                 </observers>
             </checkout_type_onepage_save_order>
-            <checkout_controller_onepage_save_shipping_method>
-                <observers>
-                    <update_bold_shipping>
-                        <class>Bold_CheckoutPaymentBooster_Observer_CheckoutObserver</class>
-                        <method>updateOrderShippingMethod</method>
-                    </update_bold_shipping>
-                </observers>
-            </checkout_controller_onepage_save_shipping_method>
         </events>
         <routers>
             <checkoutpaymentbooster>


### PR DESCRIPTION
Fixes "SHIPPING_OPTION_NOT_SELECTED" error thrown by Bold Checkout Update Order API for Digital Wallets orders placed from the Magento Checkout. This error was thrown because the preceeding call to save the shipping method in Magento failed due to the logic in the event observer that makes a call to hydrate the order using the Bold Checkout API. This hydration logic was removed by PR #71 for ticket CHK-6850, resulting in the error "Bold update failed" being thrown by the observer because the code it referenced no longer exists.

Fixes [CHK-7037](https://boldapps.atlassian.net/browse/CHK-7037)