### PR TITLE
CHK-9611: Fix RSA Auth + Rotate Key

### DIFF
--- a/Block/Adminhtml/System/Config/Button/AbstractRsaAction.php
+++ b/Block/Adminhtml/System/Config/Button/AbstractRsaAction.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * Base admin config button for RSA shared-secret actions (rotate / re-sync).
+ */
+abstract class Bold_CheckoutPaymentBooster_Block_Adminhtml_System_Config_Button_AbstractRsaAction
+    extends Mage_Adminhtml_Block_System_Config_Form_Field
+{
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->setTemplate('bold/checkout_payment_booster/system/config/button/rsa_action.phtml');
+    }
+
+    protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
+    {
+        return $this->_toHtml();
+    }
+
+    /**
+     * @return string
+     */
+    abstract public function getButtonId();
+
+    /**
+     * @return string
+     */
+    abstract public function getButtonLabel();
+
+    /**
+     * @return string
+     */
+    abstract public function getConfirmMessage();
+
+    /**
+     * @return string Controller action name without suffix, e.g. rotate
+     */
+    abstract public function getControllerAction();
+
+    /**
+     * @return array
+     */
+    protected function getScopeParams()
+    {
+        $params = array();
+        $website = $this->getRequest()->getParam('website');
+        $store = $this->getRequest()->getParam('store');
+
+        if (!$website && !$store) {
+            $requestUri = $this->getRequest()->getRequestUri();
+            if (preg_match('#/website/([^/?#]+)#', $requestUri, $matches)) {
+                $website = $matches[1];
+            } elseif (preg_match('#/store/([^/?#]+)#', $requestUri, $matches)) {
+                $store = $matches[1];
+            }
+        }
+
+        if ($website) {
+            $params['website'] = $website;
+        }
+        if ($store) {
+            $params['store'] = $store;
+        }
+
+        return $params;
+    }
+
+    /**
+     * @return string
+     */
+    public function getActionUrl()
+    {
+        return $this->getUrl(
+            'admin_bold/adminhtml_rsa/' . $this->getControllerAction(),
+            $this->getScopeParams()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getJsFunctionName()
+    {
+        return 'boldRsa' . ucfirst($this->getControllerAction());
+    }
+
+    /**
+     * @return string
+     */
+    public function getButtonHtml()
+    {
+        $button = $this->getLayout()->createBlock('adminhtml/widget_button')
+            ->setData(array(
+                'id' => $this->getButtonId(),
+                'label' => $this->getButtonLabel(),
+                'onclick' => $this->getJsFunctionName() . '()',
+                'class' => 'scalable',
+            ));
+
+        return $button->toHtml();
+    }
+
+    /**
+     * @return string
+     */
+    public function getActionScript()
+    {
+        $actionUrl = $this->getActionUrl();
+        $confirmMessage = Mage::helper('core')->jsonEncode($this->getConfirmMessage());
+        $jsFunctionName = $this->getJsFunctionName();
+        $scopeParams = $this->getScopeParams();
+        $scopeFieldsJs = '';
+
+        foreach ($scopeParams as $key => $value) {
+            $scopeFieldsJs .= '
+            form.appendChild(new Element(\'input\', {
+                type: \'hidden\',
+                name: ' . Mage::helper('core')->jsonEncode($key) . ',
+                value: ' . Mage::helper('core')->jsonEncode($value) . '
+            }));';
+        }
+
+        $scopeFallbackJs = '';
+        if (empty($scopeParams)) {
+            $scopeFallbackJs = "
+            var websiteMatch = window.location.pathname.match(/\\/website\\/([^/]+)/);
+            if (websiteMatch) {
+                form.appendChild(new Element('input', {
+                    type: 'hidden',
+                    name: 'website',
+                    value: websiteMatch[1]
+                }));
+            }
+            var storeMatch = window.location.pathname.match(/\\/store\\/([^/]+)/);
+            if (storeMatch) {
+                form.appendChild(new Element('input', {
+                    type: 'hidden',
+                    name: 'store',
+                    value: storeMatch[1]
+                }));
+            }";
+        }
+
+        return "
+        <script type='text/javascript'>
+        function {$jsFunctionName}() {
+            if (!confirm({$confirmMessage})) {
+                return;
+            }
+
+            var form = new Element('form', {
+                method: 'POST',
+                action: " . Mage::helper('core')->jsonEncode($actionUrl) . "
+            });
+
+            var token = new Element('input', {
+                type: 'hidden',
+                name: 'form_key',
+                value: FORM_KEY
+            });
+            form.appendChild(token);
+            {$scopeFieldsJs}
+            {$scopeFallbackJs}
+
+            document.body.appendChild(form);
+            form.submit();
+            document.body.removeChild(form);
+        }
+        </script>";
+    }
+}

--- a/Block/Adminhtml/System/Config/Button/RotateSharedKey.php
+++ b/Block/Adminhtml/System/Config/Button/RotateSharedKey.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Admin button to rotate the RSA shared key with Bold and save it locally after Magento auth verification.
+ */
+class Bold_CheckoutPaymentBooster_Block_Adminhtml_System_Config_Button_RotateSharedKey
+    extends Bold_CheckoutPaymentBooster_Block_Adminhtml_System_Config_Button_AbstractRsaAction
+{
+    public function getButtonId()
+    {
+        return 'bold_rotate_shared_key_button';
+    }
+
+    public function getButtonLabel()
+    {
+        return Mage::helper('core')->__('Rotate Shared Key');
+    }
+
+    public function getConfirmMessage()
+    {
+        return Mage::helper('core')->__(
+            'Rotate the shared key with Bold? This generates a new secret, registers it with Bold, verifies the change, and saves it locally.'
+        );
+    }
+
+    public function getControllerAction()
+    {
+        return 'rotate';
+    }
+}

--- a/Block/Payment/Form/Base.php
+++ b/Block/Payment/Form/Base.php
@@ -230,4 +230,45 @@ class Bold_CheckoutPaymentBooster_Block_Payment_Form_Base extends Mage_Payment_B
     {
         return Bold_CheckoutPaymentBooster_Service_Bold::getEpsAuthToken();
     }
+
+    /**
+     * Config for wallet / Express Pay Ajax in base.phtml (standard onepage checkout).
+     *
+     * @return array
+     */
+    public function getWalletCheckoutJsConfig()
+    {
+        return array(
+            'formKey' => Mage::getSingleton('core/session')->getFormKey(),
+            'quoteId' => (string) $this->quote->getId(),
+            'quoteIsVirtual' => (bool) $this->quote->getIsVirtual(),
+            'createOrderUrl' => $this->getUrl('checkoutpaymentbooster/expresspay/createOrder', array('_secure' => true)),
+            'updateOrderUrl' => $this->getUrl('checkoutpaymentbooster/expresspay/updateOrder', array('_secure' => true)),
+            'saveOrderUrl' => $this->getUrl('checkout/onepage/saveOrder', array('_secure' => true)),
+            'saveBillingUrl' => $this->getUrl('checkout/onepage/saveBilling', array('_secure' => true)),
+            'saveShippingUrl' => $this->getUrl('checkout/onepage/saveShipping', array('_secure' => true)),
+            'saveShippingMethodUrl' => $this->getUrl('checkout/onepage/saveShippingMethod', array('_secure' => true)),
+            'successUrl' => $this->getUrl('checkout/onepage/success', array('_secure' => true)),
+            'getCheckoutSessionUrl' => $this->getUrl(
+                'checkoutpaymentbooster/index/getCheckoutSession',
+                array('_secure' => true)
+            ),
+        );
+    }
+
+    /**
+     * Current Bold checkout session for client sync (public order id + tokens).
+     *
+     * @return array
+     */
+    public function getCheckoutSessionPayload()
+    {
+        return array(
+            'public_order_id' => $this->getPublicOrderID(),
+            'jwt_token' => $this->getJwtToken(),
+            'eps_auth_token' => $this->getEpsAuthToken(),
+            'bold_api_url' => $this->getBoldApiUrl(),
+            'eps_gateway_id' => $this->getEpsGatewayId(),
+        );
+    }
 }

--- a/Model/Adminhtml/System/Config/Backend/ApiToken.php
+++ b/Model/Adminhtml/System/Config/Backend/ApiToken.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Persist API token changes and track fingerprint updates.
+ *
+ * The fingerprint lets SavePipeline detect token rotation and re-register RSA
+ * without rotating the shared secret on every unrelated config save.
+ */
+class Bold_CheckoutPaymentBooster_Model_Adminhtml_System_Config_Backend_ApiToken
+    extends Mage_Adminhtml_Model_System_Config_Backend_Encrypted
+{
+    /**
+     * @return $this
+     */
+    protected function _afterSave()
+    {
+        // Registry flag is read by SavePipeline in the same request, after config save.
+        if ($this->isValueChanged()) {
+            Mage::register(
+                'bold_checkout_api_token_changed_' . $this->getScopeId(),
+                true,
+                true
+            );
+        }
+
+        $token = Mage::helper('core')->decrypt((string)$this->getValue());
+        if ($token) {
+            /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+            $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+            $config->setApiTokenFingerprint(hash('sha256', $token), (int)$this->getScopeId());
+        }
+
+        return parent::_afterSave();
+    }
+}

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -17,6 +17,8 @@ class Bold_CheckoutPaymentBooster_Model_Config
     const PATH_IS_EXPRESS_PAY_ENABLED_PDP = 'checkout/bold_checkout_payment_booster/is_expresspay_enabled_pdp';
     const PATH_EXPRESS_PAY_EMPTY_CART_PDP = 'checkout/bold_checkout_payment_booster/expresspay_empty_cart_pdp';
     const PATH_API_TOKEN = 'checkout/bold_checkout_payment_booster/api_token';
+    // sha256 of decrypted API token — used to detect token rotation without re-registering RSA on every save
+    const PATH_API_TOKEN_FINGERPRINT = 'checkout/bold_checkout_payment_booster/api_token_fingerprint';
     const PATH_SHARED_SECRET = 'checkout/bold_checkout_payment_booster/shared_secret';
     const PATH_SHOP_ID = 'checkout/bold_checkout_payment_booster/shop_id';
     const PATH_SHOP_DOMAIN = 'checkout/bold_checkout_payment_booster/shop_domain';
@@ -30,6 +32,7 @@ class Bold_CheckoutPaymentBooster_Model_Config
     const PATH_FASTLANE_ADDRESS_CONTAINER_STYLES = 'checkout/bold_checkout_payment_booster_advanced/fastlane_address_container_styles';
     const PATH_FASTLANE_EMAIL_CONTAINER_STYLES = 'checkout/bold_checkout_payment_booster_advanced/fastlane_email_container_styles';
     const PATH_IS_LOG_ENABLED = 'checkout/bold_checkout_payment_booster_advanced/is_log_enabled';
+    const PATH_IS_CHECK_SHARED_ENABLED = 'checkout/bold_checkout_payment_booster_advanced/is_check_shared_enabled';
 
     /**
      * Check if the Payment Booster is enabled.
@@ -126,6 +129,46 @@ class Bold_CheckoutPaymentBooster_Model_Config
         $encryptedToken = Mage::app()->getWebsite($websiteId)->getConfig(self::PATH_API_TOKEN);
 
         return Mage::helper('core')->decrypt($encryptedToken);
+    }
+
+    /**
+     * Retrieve stored API token fingerprint.
+     *
+     * @param int $websiteId
+     * @return string|null
+     */
+    public function getApiTokenFingerprint($websiteId)
+    {
+        return Mage::app()->getWebsite($websiteId)->getConfig(self::PATH_API_TOKEN_FINGERPRINT);
+    }
+
+    /**
+     * Save API token fingerprint.
+     *
+     * @param string $fingerprint
+     * @param int $websiteId
+     * @return void
+     */
+    public function setApiTokenFingerprint($fingerprint, $websiteId)
+    {
+        Mage::getConfig()->saveConfig(self::PATH_API_TOKEN_FINGERPRINT, $fingerprint, 'websites', $websiteId);
+        Mage::getConfig()->cleanCache();
+    }
+
+    /**
+     * Build a fingerprint for the current API token.
+     *
+     * @param int $websiteId
+     * @return string|null
+     */
+    public function buildApiTokenFingerprint($websiteId)
+    {
+        $apiToken = $this->getApiToken($websiteId);
+        if (!$apiToken) {
+            return null;
+        }
+
+        return hash('sha256', $apiToken);
     }
 
     /**
@@ -227,6 +270,15 @@ class Bold_CheckoutPaymentBooster_Model_Config
     public function isLogEnabled($websiteId)
     {
         return (bool)Mage::app()->getWebsite($websiteId)->getConfig(self::PATH_IS_LOG_ENABLED);
+    }
+
+    /**
+     * @param int $websiteId
+     * @return bool
+     */
+    public function isCheckSharedEnabled($websiteId)
+    {
+        return (bool)Mage::app()->getWebsite($websiteId)->getConfig(self::PATH_IS_CHECK_SHARED_ENABLED);
     }
 
     /**

--- a/Model/Payment/Bold.php
+++ b/Model/Payment/Bold.php
@@ -72,7 +72,11 @@ class Bold_CheckoutPaymentBooster_Model_Payment_Bold extends Mage_Payment_Model_
      */
     public function isAvailable($quote = null)
     {
-        return Bold_CheckoutPaymentBooster_Service_Bold::getBoldCheckoutData();
+        if (Mage::app()->getStore()->isAdmin()) {
+            return false;
+        }
+
+        return (bool) Bold_CheckoutPaymentBooster_Service_Bold::getBoldCheckoutData();
     }
 
     /**
@@ -82,17 +86,36 @@ class Bold_CheckoutPaymentBooster_Model_Payment_Bold extends Mage_Payment_Model_
      */
     public function getTitle()
     {
-        $infoInstance = $this->getInfoInstance();
-        if ($infoInstance && $infoInstance->getAdditionalInformation('card_details')) {
-            $cardDetails = unserialize($infoInstance->getAdditionalInformation('card_details'));
-            if (isset($cardDetails['brand']) && isset($cardDetails['last_four'])) {
-                return ucfirst($cardDetails['brand']) . ': ending in ' . $cardDetails['last_four'];
-            }
-            if (isset($cardDetails['account']) && isset($cardDetails['email'])) {
-                return 'PayPal: ' . $cardDetails['email'];
-            }
+        if (Mage::app()->getStore()->isAdmin() || !$this->hasInfoInstance()) {
+            return $this->getConfigData('title');
         }
-        return parent::getTitle();
+
+        try {
+            $infoInstance = $this->getInfoInstance();
+
+            if ($infoInstance && $infoInstance->getAdditionalInformation('title')) {
+                return $infoInstance->getAdditionalInformation('title');
+            }
+
+            $cardDetails = $infoInstance->getAdditionalInformation('card_details');
+            if ($cardDetails) {
+                $cardDetails = @unserialize($cardDetails);
+
+                if (is_array($cardDetails)) {
+                    if (isset($cardDetails['brand'], $cardDetails['last_four'])) {
+                        return ucfirst($cardDetails['brand']) . ': ending in ' . $cardDetails['last_four'];
+                    }
+
+                    if (isset($cardDetails['account'], $cardDetails['email'])) {
+                        return 'PayPal: ' . $cardDetails['email'];
+                    }
+                }
+            }
+        } catch (Exception $e) {
+            // No payment info instance in admin config / source model contexts
+        }
+
+        return $this->getConfigData('title');
     }
 
     /**

--- a/Model/Payment/Fastlane.php
+++ b/Model/Payment/Fastlane.php
@@ -72,6 +72,10 @@ class Bold_CheckoutPaymentBooster_Model_Payment_Fastlane extends Mage_Payment_Mo
      */
     public function isAvailable($quote = null)
     {
+        if (Mage::app()->getStore()->isAdmin()) {
+            return false;
+        }
+
         if (!$quote) {
             return false;
         }
@@ -99,14 +103,28 @@ class Bold_CheckoutPaymentBooster_Model_Payment_Fastlane extends Mage_Payment_Mo
      */
     public function getTitle()
     {
+        if (Mage::app()->getStore()->isAdmin() || !$this->hasInfoInstance()) {
+            return $this->getConfigData('title');
+        }
+
         $infoInstance = $this->getInfoInstance();
-        if ($infoInstance && $infoInstance->getAdditionalInformation('card_details')) {
-            $cardDetails = unserialize($infoInstance->getAdditionalInformation('card_details'));
-            if (isset($cardDetails['brand']) && isset($cardDetails['last_four'])) {
-                return ucfirst($cardDetails['brand']) . ': ending in ' . $cardDetails['last_four'];
+        $cardDetails = $infoInstance->getAdditionalInformation('card_details');
+
+        if ($cardDetails) {
+            $cardDetails = @unserialize($cardDetails);
+
+            if (is_array($cardDetails)) {
+                if (isset($cardDetails['brand'], $cardDetails['last_four'])) {
+                    return ucfirst($cardDetails['brand']) . ': ending in ' . $cardDetails['last_four'];
+                }
+
+                if (isset($cardDetails['account'], $cardDetails['email'])) {
+                    return 'PayPal: ' . $cardDetails['email'];
+                }
             }
         }
-        return parent::getTitle();
+
+        return $this->getConfigData('title');
     }
 
     /**

--- a/Model/Resource/Order/Collection.php
+++ b/Model/Resource/Order/Collection.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Bold order mapping collection.
+ */
+class Bold_CheckoutPaymentBooster_Model_Resource_Order_Collection extends Mage_Core_Model_Mysql4_Collection_Abstract
+{
+    /**
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init(Bold_CheckoutPaymentBooster_Model_Order::RESOURCE);
+    }
+}

--- a/Model/Router.php
+++ b/Model/Router.php
@@ -162,6 +162,9 @@ class Bold_CheckoutPaymentBooster_Model_Router extends Mage_Core_Controller_Vari
             $authorized = false;
         }
         if (!$authorized) {
+            // Always log auth diagnostics (not gated on is_log_enabled) so secret
+            // drift is visible without ad-hoc debug logging in production.
+            $this->logAuthFailure($websiteId);
             $this->logRequest($tracingId, 'Authorization failed.', $websiteId);
             $response->setBody(json_encode(['errors' => ['Unauthorized.']]));
             $response->setHttpResponseCode(401);
@@ -247,21 +250,55 @@ class Bold_CheckoutPaymentBooster_Model_Router extends Mage_Core_Controller_Vari
         /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
         $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
         $sharedSecret = $config->getSharedSecret($websiteId);
-        preg_match('/signature="(\S*?)"/', $request->getHeader('Signature'), $matches);
-        $signature = isset($matches[1]) ? $matches[1] : null;
-        if (!$signature) {
-            return false;
-        }
-        return hash_equals(
-            base64_encode(
-                hash_hmac(
-                    'sha256',
-                    'x-hmac-timestamp: ' . $request->getHeader('X-HMAC-Timestamp'),
-                    $sharedSecret,
-                    true
-                )
+        $signatureHeader = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::getInboundHeader(
+            $request,
+            'Signature'
+        );
+        $timestamp = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::getInboundHeader(
+            $request,
+            'X-HMAC-Timestamp'
+        );
+
+        return Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+            $sharedSecret,
+            $signatureHeader,
+            $timestamp
+        );
+    }
+
+    /**
+     * Log HMAC mismatch details for support — never logs the raw shared secret.
+     *
+     * @param int $websiteId
+     * @return void
+     */
+    private function logAuthFailure($websiteId)
+    {
+        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        $sharedSecret = $config->getSharedSecret($websiteId);
+        $request = $this->getFront()->getRequest();
+        $signatureHeader = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::getInboundHeader(
+            $request,
+            'Signature'
+        );
+        $timestamp = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::getInboundHeader(
+            $request,
+            'X-HMAC-Timestamp'
+        );
+
+        Mage::log(
+            sprintf(
+                'Bold auth result: websiteId=%s matched=NO has_signature=%s has_timestamp=%s secret_len=%s secret_sha8=%s',
+                $websiteId,
+                $signatureHeader ? 'YES' : 'NO',
+                $timestamp ? 'YES' : 'NO',
+                $sharedSecret ? strlen($sharedSecret) : 0,
+                Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint($sharedSecret)
             ),
-            $signature
+            Zend_Log::WARN,
+            Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME,
+            true
         );
     }
 }

--- a/Observer/CheckoutObserver.php
+++ b/Observer/CheckoutObserver.php
@@ -14,23 +14,59 @@ class Bold_CheckoutPaymentBooster_Observer_CheckoutObserver
      */
     public function beforeSaveOrder(Varien_Event_Observer $event)
     {
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+            5,
+            'CheckoutObserver::beforeSaveOrder (checkout_type_onepage_save_order)'
+        );
+
         /** @var Mage_Sales_Model_Order $order */
         $order = $event->getEvent()->getOrder();
         $paymentMethod = $order->getPayment()->getMethod();
-        $methodsToProcess = [
+        $methodsToProcess = array(
             Bold_CheckoutPaymentBooster_Model_Payment_Fastlane::CODE,
             Bold_CheckoutPaymentBooster_Model_Payment_Bold::CODE,
-        ];
-        if (!in_array($paymentMethod, $methodsToProcess)) {
+        );
+        if (!in_array($paymentMethod, $methodsToProcess, true)) {
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+                6,
+                'beforeSaveOrder skipped (payment=' . ($paymentMethod ?: 'none') . ')'
+            );
+
             return;
         }
-        $quote = $order->getQuote();
+
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+            6,
+            'beforeSaveOrder bold payment=' . $paymentMethod
+        );
+
+        $quote = $this->resolveQuoteForOrder($order);
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::assertQuoteCanSubmit($quote);
+
+        $epsOrderId = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::getEpsOrderIdFromRequest();
+        if ($epsOrderId) {
+            $order->getPayment()->setAdditionalInformation(
+                Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::PAYMENT_ADDITIONAL_EPS_ORDER_ID,
+                $epsOrderId
+            );
+        }
+
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+            8,
+            'beforeSaveOrder hydrate + authorize'
+        );
+
         $websiteId = $quote->getStore()->getWebsiteId();
         try {
+            Bold_CheckoutPaymentBooster_Service_Bold::initBoldCheckoutData($quote);
             Bold_CheckoutPaymentBooster_Service_Order_Hydrate::hydrate($quote);
             $publicOrderId = Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId();
             $transactionData = Bold_CheckoutPaymentBooster_Service_Payment_Auth::full($publicOrderId, $websiteId);
             $this->saveTransaction($order, $transactionData);
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+                9,
+                'beforeSaveOrder auth complete public_id=' . ($publicOrderId ?: 'none')
+            );
         } catch (Mage_Core_Exception $e) {
             Mage::log($e->getMessage(), Zend_Log::CRIT);
             Mage::throwException(Mage::helper('core')->__('Payment Authorization Failure.'));
@@ -40,34 +76,89 @@ class Bold_CheckoutPaymentBooster_Observer_CheckoutObserver
     /**
      * Save Bold order data to database after order has been placed on Magento side.
      *
-     * After Magento order has been placed, we have order id and can save Bold order data(public id) to database.
-     *
      * @param Varien_Event_Observer $event
      * @return void
      */
     public function afterSaveOrder(Varien_Event_Observer $event)
     {
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+            10,
+            'CheckoutObserver::afterSaveOrder (checkout_submit_all_after)'
+        );
+
         /** @var Mage_Sales_Model_Order $order */
         $order = $event->getEvent()->getOrder();
-        $methodsToProcess = [
+        $methodsToProcess = array(
             Bold_CheckoutPaymentBooster_Model_Payment_Fastlane::CODE,
             Bold_CheckoutPaymentBooster_Model_Payment_Bold::CODE,
-        ];
-        if (!in_array($order->getPayment()->getMethod(), $methodsToProcess)) {
+        );
+        if (!in_array($order->getPayment()->getMethod(), $methodsToProcess, true)) {
             Bold_CheckoutPaymentBooster_Service_Bold::clearBoldCheckoutData();
+
             return;
         }
+
         try {
             /** @var Bold_CheckoutPaymentBooster_Model_Order $extOrderData */
             $extOrderData = Mage::getModel(Bold_CheckoutPaymentBooster_Model_Order::RESOURCE);
             $extOrderData->setOrderId($order->getEntityId());
-            $extOrderData->setPublicId(Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId());
-            $extOrderData->save();
+            $publicOrderId = Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId();
+            $extOrderData->setPublicId($publicOrderId);
+
+            try {
+                $extOrderData->save();
+            } catch (Exception $e) {
+                if ($publicOrderId && self::isDuplicatePublicIdException($e)) {
+                    Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logDuplicateOrderAttempt(
+                        $publicOrderId,
+                        'after_save_order mapping race magento_order=' . $order->getIncrementId()
+                    );
+                } else {
+                    throw $e;
+                }
+            }
+
             Bold_CheckoutPaymentBooster_Service_Order_Update::updateOrderState($order);
             Bold_CheckoutPaymentBooster_Service_Bold::clearBoldCheckoutData();
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::clearPlacementState();
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+                11,
+                'afterSaveOrder complete order=' . $order->getIncrementId()
+            );
         } catch (Exception $e) {
             Mage::log($e->getMessage(), Zend_Log::CRIT);
         }
+    }
+
+    /**
+     * Order model often has no loaded quote during checkout_type_onepage_save_order.
+     *
+     * @param Mage_Sales_Model_Order $order
+     * @return Mage_Sales_Model_Quote
+     * @throws Mage_Core_Exception
+     */
+    private function resolveQuoteForOrder(Mage_Sales_Model_Order $order)
+    {
+        $quote = $order->getQuote();
+        if ($quote && $quote->getId()) {
+            return $quote;
+        }
+
+        if ($order->getQuoteId()) {
+            $quote = Mage::getModel('sales/quote')->load($order->getQuoteId());
+            if ($quote->getId()) {
+                return $quote;
+            }
+        }
+
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $quote = $session->getQuote();
+        if ($quote && $quote->getId()) {
+            return $quote;
+        }
+
+        Mage::throwException(Mage::helper('checkout')->__('Your shopping cart could not be found.'));
     }
 
     /**
@@ -80,20 +171,78 @@ class Bold_CheckoutPaymentBooster_Observer_CheckoutObserver
      */
     private function saveTransaction(Mage_Sales_Model_Order $order, stdClass $transactionData)
     {
-        $transactionId = isset($transactionData->transactions[0]->transaction_id)
-            ? $transactionData->transactions[0]->transaction_id
-            : null;
-        if (!$transactionId) {
-            return;
+        if (empty($transactionData->transactions)) {
+            Mage::throwException(Mage::helper('core')->__('Payment Authorization Failure.'));
         }
-        $order->getPayment()->setTransactionId($transactionId);
+
+        $transaction = $this->resolveAuthTransaction($order, $transactionData->transactions);
+        if (!$transaction || empty($transaction->transaction_id)) {
+            Mage::throwException(Mage::helper('core')->__('Payment Authorization Failure.'));
+        }
+
+        $orderAmountCents = (int) round($order->getGrandTotal() * 100);
+        if (isset($transaction->amount) && (int) $transaction->amount !== $orderAmountCents) {
+            Mage::throwException(
+                Mage::helper('core')->__(
+                    'Payment amount does not match your order total. Please refresh checkout and try again.'
+                )
+            );
+        }
+
+        $order->getPayment()->setTransactionId($transaction->transaction_id);
         $order->getPayment()->setIsTransactionClosed(0);
         $order->getPayment()->addTransaction(Mage_Sales_Model_Order_Payment_Transaction::TYPE_AUTH);
-        $cardDetails = isset($transactionData->transactions[0]->tender_details)
-            ? $transactionData->transactions[0]->tender_details
-            : null;
-        if ($cardDetails) {
-            $order->getPayment()->setAdditionalInformation('card_details', serialize((array)$cardDetails));
+        if (!empty($transaction->tender_details)) {
+            $order->getPayment()->setAdditionalInformation(
+                'card_details',
+                serialize((array) $transaction->tender_details)
+            );
         }
+    }
+
+    /**
+     * Pick the Bold auth transaction that matches the Magento payment method and order total.
+     *
+     * @param Mage_Sales_Model_Order $order
+     * @param array $transactions
+     * @return stdClass|null
+     */
+    private function resolveAuthTransaction(Mage_Sales_Model_Order $order, array $transactions)
+    {
+        $expectedTender = $order->getPayment()->getMethod() === Bold_CheckoutPaymentBooster_Model_Payment_Fastlane::CODE
+            ? 'credit_card'
+            : 'paypal';
+        $orderAmountCents = (int) round($order->getGrandTotal() * 100);
+
+        $byTender = array();
+        foreach ($transactions as $transaction) {
+            if (isset($transaction->tender_type) && $transaction->tender_type === $expectedTender) {
+                $byTender[] = $transaction;
+            }
+        }
+
+        foreach ($byTender as $transaction) {
+            if (isset($transaction->amount) && (int) $transaction->amount === $orderAmountCents) {
+                return $transaction;
+            }
+        }
+
+        if (!empty($byTender)) {
+            return end($byTender);
+        }
+
+        return isset($transactions[0]) ? $transactions[0] : null;
+    }
+
+    /**
+     * @param Exception $exception
+     * @return bool
+     */
+    private static function isDuplicatePublicIdException(Exception $exception)
+    {
+        $message = $exception->getMessage();
+
+        return stripos($message, 'Duplicate entry') !== false
+            && stripos($message, 'UNQ_BOLD_CHECKOUT_PAYMENT_BOOSTER_ORDER_PUBLIC_ID') !== false;
     }
 }

--- a/Observer/ConfigObserver.php
+++ b/Observer/ConfigObserver.php
@@ -5,86 +5,60 @@
  */
 class Bold_CheckoutPaymentBooster_Observer_ConfigObserver
 {
+    /** Group IDs that belong to this module (defined in etc/system.xml). */
+    const BOLD_CONFIG_GROUPS = array(
+        'bold_checkout_payment_booster_onboarding',
+        'bold_checkout_payment_booster',
+        'bold_checkout_payment_booster_advanced',
+    );
+
     /**
-     * Set Bold shop ID.
+     * Run Bold config save pipeline for checkout section changes.
+     *
+     * Single entry point replaces saveShopInfo, CORS, RSA, and processFlows observers
+     * so failures stop the pipeline before flows run without valid RSA.
+     *
+     * Fires on admin_system_config_changed_section_checkout (whole section), so we
+     * guard against unrelated Checkout group saves (e.g. native Magento checkout
+     * settings) by checking that at least one Bold group was included in the POST.
      *
      * @param Varien_Event_Observer $event
      * @return void
-     * @throws Mage_Core_Exception
      * @see etc/config.xml adminhtml/events: admin_system_config_changed_section_checkout
      */
-    public function saveShopInfo(Varien_Event_Observer $event)
+    public function onCheckoutConfigChanged(Varien_Event_Observer $event)
     {
+        if (!$this->isBoldGroupSubmitted()) {
+            return;
+        }
+
         $websiteId = Mage::app()->getWebsite($event->getWebsite())->getId();
         try {
-            Bold_CheckoutPaymentBooster_Service_ShopInfo::saveShopInfo($websiteId);
+            Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::run($websiteId);
         } catch (Exception $exception) {
             $this->addErrorMessage($exception->getMessage());
         }
     }
 
     /**
-     * Create|update or disable Payment Booster and Fastlane flows considering configuration.
+     * Return true when the current POST contains at least one Bold config group.
      *
-     * @param Varien_Event_Observer $event
-     * @return void
-     * @see etc/config.xml adminhtml/events: admin_system_config_changed_section_checkout
+     * @return bool
      */
-    public function processFlows(Varien_Event_Observer $event)
+    private function isBoldGroupSubmitted()
     {
-        $websiteId = Mage::app()->getWebsite($event->getWebsite())->getId();
-        try {
-            Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterFlow($websiteId);
-            Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterPdpFlow($websiteId);
-            Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterCartFlow($websiteId);
-        } catch (Exception $exception) {
-            $this->addErrorMessage($exception->getMessage());
+        $submittedGroups = Mage::app()->getRequest()->getPost('groups', array());
+        if (!is_array($submittedGroups)) {
+            return false;
         }
-    }
 
-    /**
-     * Add Magento domain for specific website to the CORS allow list.
-     *
-     * @param Varien_Event_Observer $event
-     * @return void
-     * @see etc/config.xml adminhtml/events: admin_system_config_changed_section_checkout
-     */
-    public function addDomainToCorsAllowList(Varien_Event_Observer $event)
-    {
-        try {
-            $websiteId = Mage::app()->getWebsite($event->getWebsite())->getId();
-            $defaultStore = Mage::app()->getWebsite($websiteId)->getDefaultStore();
-            $magentoUrl = $defaultStore->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB);
-            $domainList = Bold_CheckoutPaymentBooster_Service_Eps_Cors::getAllowList((int)$websiteId);
-            foreach ($domainList as $domain) {
-                if ($domain->domain === rtrim($magentoUrl, '/')) {
-                    return;
-                }
+        foreach (self::BOLD_CONFIG_GROUPS as $group) {
+            if (array_key_exists($group, $submittedGroups)) {
+                return true;
             }
-            Bold_CheckoutPaymentBooster_Service_Eps_Cors::addDomainToCorsAllowList(
-                (int)$websiteId,
-                (string)$magentoUrl
-            );
-        } catch (Mage_Core_Exception $e) {
-            $this->addErrorMessage($e->getMessage());
         }
-    }
 
-    /**
-     * Set RSA configuration.
-     *
-     * @param Varien_Event_Observer $event
-     * @return void
-     * @see etc/config.xml adminhtml/events: admin_system_config_changed_section_checkout
-     */
-    public function setRsaConfig(Varien_Event_Observer $event)
-    {
-        $websiteId = Mage::app()->getWebsite($event->getWebsite())->getId();
-        try {
-            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::setRsaConfig($websiteId);
-        } catch (Exception $exception) {
-            $this->addErrorMessage($exception->getMessage());
-        }
+        return false;
     }
 
     /**

--- a/Observer/SaveOrderObserver.php
+++ b/Observer/SaveOrderObserver.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Blocks duplicate Bold saveOrder requests (double-submit on standard checkout).
+ *
+ * Wired in etc/config.xml on predispatch/postdispatch for checkout/onepage/saveOrder.
+ * Delegates to Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard.
+ */
+class Bold_CheckoutPaymentBooster_Observer_SaveOrderObserver
+{
+    /**
+     * [vs main] Predispatch: allow first placement, block in-progress, or return success for existing order.
+     *
+     * @param Varien_Event_Observer $observer
+     * @return void
+     */
+    public function predispatchSaveOrder(Varien_Event_Observer $observer)
+    {
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+            1,
+            'SaveOrderObserver::predispatchSaveOrder'
+        );
+
+        $paymentMethod = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::getPaymentMethodFromRequest();
+        $willEvaluate = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::isBoldPaymentMethod($paymentMethod);
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logSaveOrderPredispatch(
+            $paymentMethod,
+            $willEvaluate
+        );
+
+        if (!$willEvaluate) {
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+                2,
+                'predispatch skipped (payment=' . ($paymentMethod ?: 'none') . ')'
+            );
+
+            return;
+        }
+
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+            2,
+            'predispatch evaluating guard (payment=' . $paymentMethod . ')'
+        );
+
+        $evaluation = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::evaluatePlacementRequest();
+
+        if ($evaluation['action'] === 'allow') {
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+                4,
+                'predispatch allow'
+            );
+
+            return;
+        }
+
+        if ($evaluation['action'] === 'success_existing' && !empty($evaluation['order'])) {
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+                4,
+                'predispatch success_existing order=' . $evaluation['order']->getIncrementId()
+            );
+            /** @var Mage_Core_Controller_Varien_Action $controller */
+            $controller = $observer->getEvent()->getControllerAction();
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::respondWithExistingOrderSuccess(
+                $controller,
+                $evaluation['order']
+            );
+
+            return;
+        }
+
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+            4,
+            'predispatch block action=' . $evaluation['action']
+        );
+
+        $message = !empty($evaluation['message'])
+            ? $evaluation['message']
+            : Mage::helper('checkout')->__('Unable to place your order. Please try again.');
+
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::blockPlacement($message);
+    }
+
+    /**
+     * [vs main] Postdispatch: clear session placement flag and MySQL lock after saveOrder completes or fails.
+     *
+     * @param Varien_Event_Observer $observer
+     * @return void
+     */
+    public function cleanupAfterSaveOrder(Varien_Event_Observer $observer)
+    {
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logStep(
+            12,
+            'SaveOrderObserver::cleanupAfterSaveOrder'
+        );
+
+        $paymentMethod = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::getPaymentMethodFromRequest();
+        if (!Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::isBoldPaymentMethod($paymentMethod)) {
+            return;
+        }
+
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        if ($session->getLastSuccessQuoteId()) {
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::clearPlacementState();
+
+            return;
+        }
+
+        if ($session->getData(Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::SESSION_PLACEMENT_FLAG)) {
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::clearPlacementState();
+        }
+    }
+}

--- a/Service/Bold.php
+++ b/Service/Bold.php
@@ -31,10 +31,27 @@ class Bold_CheckoutPaymentBooster_Service_Bold
                 return;
             }
         }
+        $previousPublicOrderId = self::getPublicOrderId();
         $checkoutData = Bold_CheckoutPaymentBooster_Service_Order_Init::init($quote, $flowId);
         /** @var Mage_Checkout_Model_Session $checkoutSession */
         $checkoutSession = Mage::getSingleton('checkout/session');
         $checkoutSession->setBoldCheckoutData($checkoutData);
+
+        $newPublicOrderId = isset($checkoutData->public_order_id) ? $checkoutData->public_order_id : null;
+        if ($previousPublicOrderId && $newPublicOrderId && $previousPublicOrderId !== $newPublicOrderId) {
+            Mage::log(
+                sprintf(
+                    '[BoldCheckout] public_order_id rotated quote=%s %s -> %s',
+                    $quote->getId(),
+                    $previousPublicOrderId,
+                    $newPublicOrderId
+                ),
+                Zend_Log::INFO,
+                Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME,
+                true
+            );
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::clearWalletEpsOrderId();
+        }
     }
 
     /**

--- a/Service/BoldClient.php
+++ b/Service/BoldClient.php
@@ -50,7 +50,7 @@ class Bold_CheckoutPaymentBooster_Service_BoldClient
                 $path,
                 $websiteId,
                 $headers,
-                $body ? json_encode($body) : ''
+                self::encodeRequestBody($body)
             )
         );
     }
@@ -75,7 +75,7 @@ class Bold_CheckoutPaymentBooster_Service_BoldClient
                 $path,
                 $websiteId,
                 $headers,
-                $body ? json_encode($body) : ''
+                self::encodeRequestBody($body)
             )
         );
     }
@@ -100,7 +100,7 @@ class Bold_CheckoutPaymentBooster_Service_BoldClient
                 $path,
                 $websiteId,
                 $headers,
-                $body ? json_encode($body) : ''
+                self::encodeRequestBody($body)
             )
         );
     }
@@ -126,6 +126,19 @@ class Bold_CheckoutPaymentBooster_Service_BoldClient
                 $headers
             )
         );
+    }
+
+    /**
+     * @param array|null $body
+     * @return string
+     */
+    private static function encodeRequestBody(array $body = null)
+    {
+        if ($body === null || $body === array()) {
+            return '{}';
+        }
+
+        return json_encode($body);
     }
 
     /**

--- a/Service/Client/Http.php
+++ b/Service/Client/Http.php
@@ -21,8 +21,24 @@ class Bold_CheckoutPaymentBooster_Service_Client_Http
         $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
         $tracingId = sha1(microtime());
         if ($config->isLogEnabled($websiteId)) {
+            $incomingRequest = self::collectIncomingRequestMetadata();
+            if ($incomingRequest !== array()) {
+                Mage::log(
+                    $tracingId . ': Incoming request: ' . json_encode($incomingRequest),
+                    Zend_Log::DEBUG,
+                    Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME,
+                    true
+                );
+            }
+
             Mage::log(
                 $tracingId . ': Outgoing Call: ' . $method . ' ' . $url,
+                Zend_Log::DEBUG,
+                Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME,
+                true
+            );
+            Mage::log(
+                $tracingId . ': Outgoing Call headers: ' . json_encode(self::sanitizeHeaderList($headers)),
                 Zend_Log::DEBUG,
                 Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME,
                 true
@@ -170,5 +186,106 @@ class Bold_CheckoutPaymentBooster_Service_Client_Http
             curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
         }
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, 'DELETE');
+    }
+
+    /**
+     * Incoming Magento HTTP request metadata (browser → shop), for bold_checkout_payment_booster.log.
+     *
+     * @return array
+     */
+    private static function collectIncomingRequestMetadata()
+    {
+        if (!method_exists('Mage', 'app')) {
+            return array();
+        }
+
+        /** @var Mage_Core_Controller_Request_Http $request */
+        $request = Mage::app()->getRequest();
+
+        return array(
+            'method' => $request->getMethod(),
+            'path' => $request->getRequestUri(),
+            'remote_addr' => $request->getClientIp(false),
+            'is_ajax' => $request->isXmlHttpRequest(),
+            'headers' => self::collectIncomingRequestHeaders(),
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function collectIncomingRequestHeaders()
+    {
+        $raw = array();
+        if (function_exists('getallheaders')) {
+            $fromApache = getallheaders();
+            if (is_array($fromApache)) {
+                $raw = $fromApache;
+            }
+        }
+
+        if ($raw === array()) {
+            foreach ($_SERVER as $name => $value) {
+                if (strpos($name, 'HTTP_') !== 0) {
+                    continue;
+                }
+
+                $headerName = str_replace(
+                    ' ',
+                    '-',
+                    ucwords(strtolower(str_replace('_', ' ', substr($name, 5))))
+                );
+                $raw[$headerName] = $value;
+            }
+        }
+
+        return self::sanitizeHeaderMap($raw);
+    }
+
+    /**
+     * @param array $headers Outgoing curl headers (numeric keys) or name => value map.
+     * @return array
+     */
+    private static function sanitizeHeaderList(array $headers)
+    {
+        $map = array();
+        foreach ($headers as $key => $value) {
+            if (is_int($key) && is_string($value) && strpos($value, ':') !== false) {
+                list($name, $headerValue) = explode(':', $value, 2);
+                $map[trim($name)] = trim($headerValue);
+            } else {
+                $map[(string) $key] = (string) $value;
+            }
+        }
+
+        return self::sanitizeHeaderMap($map);
+    }
+
+    /**
+     * @param array $headers
+     * @return array<string, string>
+     */
+    private static function sanitizeHeaderMap(array $headers)
+    {
+        $redacted = array(
+            'authorization',
+            'proxy-authorization',
+            'cookie',
+            'set-cookie',
+            'x-api-key',
+            'x-auth-token',
+        );
+
+        $sanitized = array();
+        foreach ($headers as $name => $value) {
+            $normalized = strtolower(trim($name));
+            $sanitized[$normalized] = in_array($normalized, $redacted, true)
+                ? '[REDACTED]'
+                : (strlen($value) > 500 ? substr($value, 0, 500) . '…' : (string) $value);
+        }
+
+        ksort($sanitized);
+
+        return $sanitized;
     }
 }

--- a/Service/Config/SavePipeline.php
+++ b/Service/Config/SavePipeline.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Orchestrate Bold config save side effects in a safe order.
+ *
+ * Replaces four independent observers so RSA registration cannot run after a
+ * partial failure left shop_id empty, and flows are not provisioned when RSA fails.
+ */
+class Bold_CheckoutPaymentBooster_Service_Config_SavePipeline
+{
+    /**
+     * @param int $websiteId
+     * @param array $options
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    public static function run($websiteId, array $options = array())
+    {
+        $forceRsa = !empty($options['force_rsa']);
+
+        // Order matters: shop_id must exist before RSA; RSA must succeed before flows.
+        Bold_CheckoutPaymentBooster_Service_ShopInfo::saveShopInfo($websiteId);
+        self::validateShopDomain($websiteId); // notice only — does not abort
+        Bold_CheckoutPaymentBooster_Service_Eps_CorsRegistration::registerWebsiteDomain($websiteId);
+
+        if (self::shouldRotateRsa($websiteId, $forceRsa)) {
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::registerRsaConfig($websiteId, true);
+        } else {
+            Mage::log(
+                'RSA registration skipped (no rotation trigger)',
+                Zend_Log::DEBUG,
+                Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME
+            );
+        }
+
+        Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterFlow($websiteId);
+        Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterPdpFlow($websiteId);
+        Bold_CheckoutPaymentBooster_Service_Flow::processPaymentBoosterCartFlow($websiteId);
+    }
+
+    /**
+     * @param int $websiteId
+     * @param bool $force
+     * @return bool
+     */
+    public static function shouldRotateRsa($websiteId, $force = false)
+    {
+        if ($force) {
+            return true;
+        }
+
+        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+
+        // First-time setup: no local secret yet.
+        if (!$config->getSharedSecret($websiteId)) {
+            return true;
+        }
+
+        // Set by ApiToken backend when the admin saves a new token this request.
+        if (Mage::registry('bold_checkout_api_token_changed_' . $websiteId)) {
+            return true;
+        }
+
+        // Fallback if registry was cleared but fingerprint still differs.
+        $storedFingerprint = $config->getApiTokenFingerprint($websiteId);
+        $currentFingerprint = $config->buildApiTokenFingerprint($websiteId);
+        if ($currentFingerprint && $storedFingerprint !== $currentFingerprint) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Warn when Bold shop domain and Magento base URL hosts do not align.
+     *
+     * @param int $websiteId
+     * @return void
+     */
+    public static function validateShopDomain($websiteId)
+    {
+        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        $boldDomain = self::normalizeHost($config->getShopDomain($websiteId));
+        $defaultStore = Mage::app()->getWebsite($websiteId)->getDefaultStore();
+        $magentoHost = self::normalizeHost($defaultStore->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB));
+
+        if ($boldDomain === '' || $magentoHost === '') {
+            return;
+        }
+
+        // www vs apex mismatch (e.g. lethalperformance.com vs www.lethalperformance.com)
+        // does not block save but causes webhook/callback confusion if left unaddressed.
+        if (self::hostsMatch($boldDomain, $magentoHost)) {
+            return;
+        }
+
+        Mage::getSingleton('adminhtml/session')->addNotice(
+            Mage::helper('core')->__(
+                'Bold shop domain (%s) does not match the Magento base URL host (%s). Ensure www/apex redirects and Bold Account Center use the same canonical domain.',
+                $boldDomain,
+                $magentoHost
+            )
+        );
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     */
+    public static function normalizeHost($value)
+    {
+        $value = strtolower(trim((string)$value));
+        if ($value === '') {
+            return '';
+        }
+
+        $parts = parse_url(strpos($value, '://') === false ? 'https://' . $value : $value);
+        if (!isset($parts['host'])) {
+            return rtrim($value, '/');
+        }
+
+        return strtolower($parts['host']);
+    }
+
+    /**
+     * @param string $left
+     * @param string $right
+     * @return bool
+     */
+    public static function hostsMatch($left, $right)
+    {
+        if ($left === $right) {
+            return true;
+        }
+
+        $stripWww = function ($host) {
+            return preg_replace('/^www\./', '', $host);
+        };
+
+        return $stripWww($left) === $stripWww($right);
+    }
+}

--- a/Service/Eps/CorsRegistration.php
+++ b/Service/Eps/CorsRegistration.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Register Magento storefront domains with Bold EPS CORS allow list.
+ *
+ * Extracted from ConfigObserver so SavePipeline can run CORS in a fixed order.
+ */
+class Bold_CheckoutPaymentBooster_Service_Eps_CorsRegistration
+{
+    /**
+     * @param int $websiteId
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    public static function registerWebsiteDomain($websiteId)
+    {
+        $defaultStore = Mage::app()->getWebsite($websiteId)->getDefaultStore();
+        $magentoUrl = $defaultStore->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB);
+        $domainList = Bold_CheckoutPaymentBooster_Service_Eps_Cors::getAllowList((int)$websiteId);
+        foreach ($domainList as $domain) {
+            if ($domain->domain === rtrim($magentoUrl, '/')) {
+                return;
+            }
+        }
+
+        Bold_CheckoutPaymentBooster_Service_Eps_Cors::addDomainToCorsAllowList(
+            (int)$websiteId,
+            (string)$magentoUrl
+        );
+    }
+}

--- a/Service/Inbound/Auth.php
+++ b/Service/Inbound/Auth.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Inbound Bold webhook HMAC verification helpers.
+ */
+class Bold_CheckoutPaymentBooster_Service_Inbound_Auth
+{
+    /**
+     * @param Zend_Controller_Request_Http $request
+     * @param string $name
+     * @return string|null
+     */
+    public static function getInboundHeader(Zend_Controller_Request_Http $request, $name)
+    {
+        $header = $request->getHeader($name);
+        if ($header) {
+            return $header;
+        }
+
+        // nginx/Apache rewrites may expose HMAC headers only via $_SERVER, not getHeader().
+        $serverKey = 'HTTP_' . str_replace('-', '_', strtoupper($name));
+        if (isset($_SERVER[$serverKey]) && $_SERVER[$serverKey] !== '') {
+            return $_SERVER[$serverKey];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string|null $sharedSecret
+     * @param string|null $signatureHeader
+     * @param string|null $timestamp
+     * @return bool
+     */
+    public static function verifyHmac($sharedSecret, $signatureHeader, $timestamp)
+    {
+        if (!$sharedSecret || !$signatureHeader || !$timestamp) {
+            return false;
+        }
+
+        preg_match('/signature="(\S*?)"/', $signatureHeader, $matches);
+        $signature = isset($matches[1]) ? $matches[1] : null;
+        if (!$signature) {
+            return false;
+        }
+
+        $expected = base64_encode(
+            hash_hmac(
+                'sha256',
+                'x-hmac-timestamp: ' . $timestamp,
+                $sharedSecret,
+                true
+            )
+        );
+
+        return hash_equals($expected, $signature);
+    }
+
+    /**
+     * Build the Signature header Bold sends on inbound REST webhooks.
+     *
+     * @param string $sharedSecret
+     * @param string $timestamp
+     * @return string
+     */
+    public static function buildBoldSignatureHeader($sharedSecret, $timestamp)
+    {
+        $signature = base64_encode(
+            hash_hmac(
+                'sha256',
+                'x-hmac-timestamp: ' . $timestamp,
+                $sharedSecret,
+                true
+            )
+        );
+
+        return 'keyId="X-HMAC",algorithm="hmac-sha256",headers="x-hmac-timestamp",signature="'
+            . $signature
+            . '"';
+    }
+
+    /**
+     * RFC1123 timestamp used by Bold inbound webhook signatures.
+     *
+     * @return string
+     */
+    public static function buildBoldTimestamp()
+    {
+        return gmdate('D, d M y H:i:s') . ' +0000';
+    }
+
+    /**
+     * Safe log identifier for diagnosing secret drift without logging the secret itself.
+     */
+    public static function secretFingerprint($sharedSecret)
+    {
+        if (!$sharedSecret) {
+            return '00000000';
+        }
+
+        return substr(hash('sha256', $sharedSecret), 0, 8);
+    }
+}

--- a/Service/Order/CheckoutSessionOwnership.php
+++ b/Service/Order/CheckoutSessionOwnership.php
@@ -1,0 +1,263 @@
+<?php
+
+/**
+ * Verifies Magento orders and quotes belong to the current checkout session.
+ */
+class Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership
+{
+    const EXCEPTION_QUOTE_ACCESS_DENIED = 403;
+
+    /** Checkout session key for EPS wallet_pay order id created in this session. */
+    const SESSION_WALLET_EPS_ORDER_ID = 'bold_wallet_eps_order_id';
+    const SESSION_WALLET_EPS_QUOTE_ID = 'bold_wallet_eps_quote_id';
+    const SESSION_WALLET_EPS_CREATED_AT = 'bold_wallet_eps_created_at';
+    /** Seconds to reuse the same wallet_pay order id for parallel createOrder calls. */
+    const WALLET_EPS_COALESCE_SECONDS = 15;
+
+    /**
+     * @param Mage_Sales_Model_Order $order
+     * @param Mage_Sales_Model_Quote $quote
+     * @return bool
+     */
+    public static function orderBelongsToCheckoutSession(Mage_Sales_Model_Order $order, Mage_Sales_Model_Quote $quote)
+    {
+        if (!$order->getId() || !$quote->getId()) {
+            return false;
+        }
+
+        if ((int) $order->getQuoteId() !== (int) $quote->getId()) {
+            return false;
+        }
+
+        $orderCustomerId = (int) $order->getCustomerId();
+        $quoteCustomerId = (int) $quote->getCustomerId();
+
+        if ($orderCustomerId > 0 && $quoteCustomerId > 0) {
+            return $orderCustomerId === $quoteCustomerId;
+        }
+
+        $orderEmail = self::normalizeEmail(self::getOrderEmail($order));
+        $quoteEmail = self::normalizeEmail((string) $quote->getCustomerEmail());
+
+        if ($orderEmail !== '' && $quoteEmail !== '') {
+            return $orderEmail === $quoteEmail;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param Mage_Sales_Model_Order $order
+     * @param Mage_Sales_Model_Quote $quote
+     * @param string $context
+     * @return array{action:string,order?:Mage_Sales_Model_Order,message?:string}
+     */
+    public static function buildSuccessExistingEvaluation(
+        Mage_Sales_Model_Order $order,
+        Mage_Sales_Model_Quote $quote,
+        $context
+    ) {
+        if (self::orderBelongsToCheckoutSession($order, $quote)) {
+            return array(
+                'action' => 'success_existing',
+                'order' => $order,
+            );
+        }
+
+        $logId = $order->getIncrementId() ?: (string) $order->getId();
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::logDuplicateOrderAttempt(
+            $logId,
+            'success_existing_rejected_' . $context
+        );
+
+        return array(
+            'action' => 'block',
+            'message' => Mage::helper('checkout')->__(
+                'This Bold payment has already been used to place an order.'
+            ),
+        );
+    }
+
+    /**
+     * @param Mage_Sales_Model_Quote $quote
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    public static function assertQuoteMatchesCheckoutSession(Mage_Sales_Model_Quote $quote)
+    {
+        if (!$quote->getId()) {
+            Mage::throwException(
+                Mage::helper('checkout')->__('Your shopping cart could not be found.')
+            );
+        }
+
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $sessionQuoteId = (int) $session->getQuoteId();
+
+        if ($sessionQuoteId <= 0 || (int) $quote->getId() !== $sessionQuoteId) {
+            throw new Mage_Core_Exception(
+                Mage::helper('checkout')->__('You are not authorized to access this cart.'),
+                self::EXCEPTION_QUOTE_ACCESS_DENIED
+            );
+        }
+    }
+
+    /**
+     * @param string|null $quoteIdParam
+     * @return Mage_Sales_Model_Quote
+     * @throws Mage_Core_Exception
+     */
+    public static function loadCheckoutSessionQuote($quoteIdParam)
+    {
+        if ($quoteIdParam === null || $quoteIdParam === '') {
+            /** @var Mage_Sales_Model_Quote $quote */
+            $quote = Mage::getSingleton('checkout/session')->getQuote();
+            self::assertQuoteMatchesCheckoutSession($quote);
+
+            return $quote;
+        }
+
+        /** @var Mage_Sales_Model_Quote $quote */
+        $quote = Mage::getModel('sales/quote')->load($quoteIdParam);
+
+        if (!$quote->getId()) {
+            Mage::throwException(
+                Mage::helper('core')->__('Invalid quote ID "%s".', $quoteIdParam)
+            );
+        }
+
+        self::assertQuoteMatchesCheckoutSession($quote);
+
+        return $quote;
+    }
+
+    /**
+     * Remember wallet_pay order id for this checkout session (after expresspay/createOrder).
+     *
+     * @param string $epsOrderId
+     * @return void
+     */
+    public static function registerWalletEpsOrderId($epsOrderId)
+    {
+        if ($epsOrderId === '') {
+            return;
+        }
+
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $session->setData(self::SESSION_WALLET_EPS_ORDER_ID, (string) $epsOrderId);
+    }
+
+    /**
+     * @param int $quoteId
+     * @return string
+     */
+    public static function getRecentWalletEpsOrderId($quoteId)
+    {
+        if ($quoteId <= 0) {
+            return '';
+        }
+
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $epsOrderId = (string) $session->getData(self::SESSION_WALLET_EPS_ORDER_ID);
+        $storedQuoteId = (int) $session->getData(self::SESSION_WALLET_EPS_QUOTE_ID);
+        $createdAt = (int) $session->getData(self::SESSION_WALLET_EPS_CREATED_AT);
+
+        if ($epsOrderId === ''
+            || $storedQuoteId !== $quoteId
+            || $createdAt <= 0
+            || (time() - $createdAt) > self::WALLET_EPS_COALESCE_SECONDS) {
+            return '';
+        }
+
+        return $epsOrderId;
+    }
+
+    /**
+     * @param int $quoteId
+     * @param string $epsOrderId
+     * @return void
+     */
+    public static function rememberWalletEpsOrderCreate($quoteId, $epsOrderId)
+    {
+        if ($quoteId <= 0 || $epsOrderId === '') {
+            return;
+        }
+
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $session->setData(self::SESSION_WALLET_EPS_ORDER_ID, (string) $epsOrderId);
+        $session->setData(self::SESSION_WALLET_EPS_QUOTE_ID, $quoteId);
+        $session->setData(self::SESSION_WALLET_EPS_CREATED_AT, time());
+    }
+
+    /**
+     * Clear wallet EPS order id when Bold public order rotates.
+     *
+     * @return void
+     */
+    public static function clearWalletEpsOrderId()
+    {
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $session->unsetData(self::SESSION_WALLET_EPS_ORDER_ID);
+        $session->unsetData(self::SESSION_WALLET_EPS_QUOTE_ID);
+        $session->unsetData(self::SESSION_WALLET_EPS_CREATED_AT);
+    }
+
+    /**
+     * @param string $epsOrderId
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    public static function assertWalletEpsOrderIdBelongsToSession($epsOrderId)
+    {
+        if ($epsOrderId === '') {
+            throw new Mage_Core_Exception(
+                Mage::helper('checkout')->__('You are not authorized to access this payment.'),
+                self::EXCEPTION_QUOTE_ACCESS_DENIED
+            );
+        }
+
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $registered = (string) $session->getData(self::SESSION_WALLET_EPS_ORDER_ID);
+
+        if ($registered === '' || $registered !== (string) $epsOrderId) {
+            throw new Mage_Core_Exception(
+                Mage::helper('checkout')->__('You are not authorized to access this payment.'),
+                self::EXCEPTION_QUOTE_ACCESS_DENIED
+            );
+        }
+    }
+
+    /**
+     * @param Mage_Sales_Model_Order $order
+     * @return string
+     */
+    private static function getOrderEmail(Mage_Sales_Model_Order $order)
+    {
+        $email = (string) $order->getCustomerEmail();
+        if ($email !== '') {
+            return $email;
+        }
+
+        $billingAddress = $order->getBillingAddress();
+        if ($billingAddress && $billingAddress->getEmail()) {
+            return (string) $billingAddress->getEmail();
+        }
+
+        return '';
+    }
+
+    /**
+     * @param string $email
+     * @return string
+     */
+    private static function normalizeEmail($email)
+    {
+        return strtolower(trim($email));
+    }
+}

--- a/Service/Order/PlacementGuard.php
+++ b/Service/Order/PlacementGuard.php
@@ -1,0 +1,914 @@
+<?php
+
+/**
+ * Prevents duplicate Magento orders for the same Bold checkout session or Express Pay order.
+ *
+ * CHANGES vs main: new file. Used by SaveOrderObserver (predispatch saveOrder) and CheckoutObserver.
+ *
+ * Flow:
+ * 1. predispatch saveOrder → evaluatePlacementRequest() → allow | block | success_existing (redirect JSON).
+ * 2. checkout_type_onepage_save_order → assertQuoteCanSubmit() before Magento creates order.
+ *
+ * Identifiers checked: Bold public_order_id (session), payment[additional_data][order_id] (wallet/EPS),
+ * quote_id, MySQL GET_LOCK per public order id.
+ */
+class Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard
+{
+    /** Session flag set while first saveOrder is in flight (blocks double-submit). */
+    const SESSION_PLACEMENT_FLAG = 'bold_order_placement_in_progress';
+
+    /** Payment additional_information key for EPS wallet order id (exact lookup). */
+    const PAYMENT_ADDITIONAL_EPS_ORDER_ID = 'bold_eps_order_id';
+
+    /**
+     * @var string|null
+     */
+    private static $heldLockPublicId = null;
+
+    /**
+     * Simple numbered trace for debugging observer/guard flow (always forceLog).
+     *
+     * @param int|string $step
+     * @param string $message
+     * @return void
+     */
+    public static function logStep($step, $message)
+    {
+        $detail = trim($message);
+        $path = self::getRequestPathSafe();
+        if ($path) {
+            $detail .= ' | ' . $path;
+        }
+
+        Mage::log(
+            '[Bold_Booster] step ' . $step . ': ' . $detail,
+            defined('Zend_Log::DEBUG') ? Zend_Log::DEBUG : 7,
+            Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME,
+            true
+        );
+    }
+
+    /**
+     * Duplicate-check sub-step under a parent step (always forceLog).
+     *
+     * @param int|string $parentStep
+     * @param string $check
+     * @param string $outcome
+     * @param string $detail
+     * @return void
+     */
+    public static function logDupStep($parentStep, $check, $outcome, $detail = '')
+    {
+        $message = 'dup ' . $check . ' ' . $outcome;
+        if ($detail !== '') {
+            $message .= ' ' . $detail;
+        }
+
+        self::logStep($parentStep . '-dup', $message);
+    }
+
+    /**
+     * Predispatch saveOrder entry (logs even when payment method is skipped).
+     *
+     * @param string|null $paymentMethod
+     * @param bool $willEvaluate
+     * @return void
+     */
+    public static function logSaveOrderPredispatch($paymentMethod, $willEvaluate)
+    {
+        self::writeLog('[PlacementGuard] ' . json_encode(array(
+            'event' => 'saveOrder_predispatch',
+            'payment_method' => $paymentMethod,
+            'will_evaluate' => $willEvaluate,
+            'request_path' => self::getRequestPathSafe(),
+        )));
+    }
+
+    /**
+     * @return string|null
+     */
+    private static function getRequestPathSafe()
+    {
+        try {
+            return Mage::app()->getRequest()->getRequestUri();
+        } catch (Exception $e) {
+            return null;
+        } catch (Error $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getBoldPaymentMethodCodes()
+    {
+        return array(
+            Bold_CheckoutPaymentBooster_Model_Payment_Bold::CODE,
+            Bold_CheckoutPaymentBooster_Model_Payment_Fastlane::CODE,
+        );
+    }
+
+    /**
+     * @param string|null $method
+     * @return bool
+     */
+    public static function isBoldPaymentMethod($method)
+    {
+        return $method && in_array($method, self::getBoldPaymentMethodCodes(), true);
+    }
+
+    /**
+     * @return string|null
+     */
+    public static function getPaymentMethodFromRequest()
+    {
+        $payment = Mage::app()->getRequest()->getParam('payment');
+        if (is_array($payment) && !empty($payment['method'])) {
+            return $payment['method'];
+        }
+
+        $quote = Mage::getSingleton('checkout/session')->getQuote();
+        if ($quote && $quote->getId() && $quote->getPayment()) {
+            return $quote->getPayment()->getMethod();
+        }
+
+        return null;
+    }
+
+    /**
+     * [vs main] Wallet/Express Pay order id from payment[additional_data][order_id] on saveOrder POST.
+     *
+     * @return string|null
+     */
+    public static function getEpsOrderIdFromRequest()
+    {
+        $payment = Mage::app()->getRequest()->getParam('payment');
+        if (!is_array($payment) || empty($payment['additional_data'])) {
+            return null;
+        }
+
+        $additionalData = $payment['additional_data'];
+        if (is_string($additionalData)) {
+            parse_str($additionalData, $additionalData);
+        }
+
+        if (!is_array($additionalData) || empty($additionalData['order_id'])) {
+            return null;
+        }
+
+        return (string) $additionalData['order_id'];
+    }
+
+    /**
+     * @param string $publicOrderId
+     * @return Mage_Sales_Model_Order|null
+     */
+    public static function findOrderByPublicId($publicOrderId)
+    {
+        /** @var Bold_CheckoutPaymentBooster_Model_Resource_Order_Collection $collection */
+        $collection = Mage::getModel('bold_checkout_payment_booster/order')->getCollection();
+        $collection->addFieldToFilter('public_id', $publicOrderId);
+        $collection->addFieldToFilter('order_id', array('notnull' => true));
+        $collection->setPageSize(1);
+
+        $mapping = $collection->getFirstItem();
+        if (!$mapping->getId() || !$mapping->getOrderId()) {
+            return null;
+        }
+
+        $order = Mage::getModel('sales/order')->load($mapping->getOrderId());
+
+        return $order->getId() ? $order : null;
+    }
+
+    /**
+     * @param string $publicOrderId
+     * @param string $context
+     * @return void
+     */
+    public static function logDuplicateOrderAttempt($publicOrderId, $context = '')
+    {
+        if (!$publicOrderId) {
+            return;
+        }
+
+        $message = sprintf('order %s was attempt to duplicate', $publicOrderId);
+        if ($context !== '') {
+            $message .= ' [' . $context . ']';
+        }
+
+        self::writeLog(
+            '[DuplicateOrder] ' . $message,
+            defined('Zend_Log::WARN') ? Zend_Log::WARN : 4
+        );
+    }
+
+    /**
+     * @param string $phase predispatch|assert_submit
+     * @param string $check
+     * @param string $outcome
+     * @param array $context
+     * @return void
+     */
+    private static function logPlacementCheck($phase, $check, $outcome, array $context = array())
+    {
+        $payload = array(
+            'phase' => $phase,
+            'check' => $check,
+            'outcome' => $outcome,
+        );
+
+        if ($context !== array()) {
+            $payload['context'] = $context;
+        }
+
+        self::writeLog('[PlacementGuard] ' . json_encode($payload));
+    }
+
+    /**
+     * Same logging path as Bold API logs: bold_checkout_payment_booster.log with forceLog.
+     *
+     * @param string $message
+     * @param int $level
+     * @return void
+     */
+    private static function writeLog($message, $level = null)
+    {
+        if (!self::isBoldLoggingEnabled()) {
+            return;
+        }
+
+        if ($level === null) {
+            $level = defined('Zend_Log::DEBUG') ? Zend_Log::DEBUG : 7;
+        }
+
+        Mage::log(
+            $message,
+            $level,
+            Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME,
+            true
+        );
+    }
+
+    /**
+     * @return bool
+     */
+    private static function isBoldLoggingEnabled()
+    {
+        if (!class_exists('Bold_CheckoutPaymentBooster_Model_Config', false)) {
+            return false;
+        }
+
+        try {
+            /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+            $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+            if (!$config) {
+                return false;
+            }
+
+            return $config->isLogEnabled(self::resolveWebsiteIdForLogging());
+        } catch (Exception $e) {
+            return false;
+        } catch (Error $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return int
+     */
+    private static function resolveWebsiteIdForLogging()
+    {
+        try {
+            /** @var Mage_Checkout_Model_Session $session */
+            $session = Mage::getSingleton('checkout/session');
+            $quote = $session->getQuote();
+            if ($quote && $quote->getId() && $quote->getStore()) {
+                return (int) $quote->getStore()->getWebsiteId();
+            }
+        } catch (Exception $e) {
+            // fall through
+        } catch (Error $e) {
+            // fall through
+        }
+
+        return (int) Mage::app()->getStore()->getWebsiteId();
+    }
+
+    /**
+     * @param Mage_Sales_Model_Quote|null $quote
+     * @param string|null $publicOrderId
+     * @param string|null $epsOrderId
+     * @param Mage_Checkout_Model_Session $session
+     * @return array
+     */
+    private static function buildPlacementContext($quote, $publicOrderId, $epsOrderId, Mage_Checkout_Model_Session $session)
+    {
+        return array(
+            'quote_id' => $quote && $quote->getId() ? (int) $quote->getId() : null,
+            'quote_active' => $quote && $quote->getId() ? (bool) $quote->getIsActive() : null,
+            'public_order_id' => $publicOrderId !== null && $publicOrderId !== '' ? $publicOrderId : null,
+            'eps_order_id' => $epsOrderId !== null && $epsOrderId !== '' ? $epsOrderId : null,
+            'placement_in_progress' => (bool) $session->getData(self::SESSION_PLACEMENT_FLAG),
+            'payment_method' => self::getPaymentMethodFromRequestSafe(),
+        );
+    }
+
+    /**
+     * @return string|null
+     */
+    private static function getPaymentMethodFromRequestSafe()
+    {
+        if (!method_exists('Mage', 'app')) {
+            return null;
+        }
+
+        try {
+            return self::getPaymentMethodFromRequest();
+        } catch (Exception $e) {
+            return null;
+        } catch (Error $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param int $quoteId
+     * @return Mage_Sales_Model_Order|null
+     */
+    public static function findOrderByQuoteId($quoteId)
+    {
+        $order = Mage::getModel('sales/order')->loadByAttribute('quote_id', $quoteId);
+
+        return $order->getId() ? $order : null;
+    }
+
+    /**
+     * @param string $epsOrderId
+     * @return Mage_Sales_Model_Order|null
+     */
+    public static function findOrderByEpsOrderId($epsOrderId)
+    {
+        if ($epsOrderId === '') {
+            return null;
+        }
+
+        $serializedValue = 's:' . strlen($epsOrderId) . ':"' . $epsOrderId . '"';
+
+        /** @var Mage_Sales_Model_Resource_Order_Payment_Collection $collection */
+        $collection = Mage::getModel('sales/order_payment')->getCollection();
+        $collection->addFieldToFilter('method', array('in' => self::getBoldPaymentMethodCodes()));
+        $collection->addFieldToFilter('additional_information', array('like' => '%' . $serializedValue . '%'));
+        $collection->setPageSize(1);
+
+        $payment = $collection->getFirstItem();
+        if (!$payment->getId()) {
+            return null;
+        }
+
+        if ($payment->getAdditionalInformation(self::PAYMENT_ADDITIONAL_EPS_ORDER_ID) !== $epsOrderId) {
+            return null;
+        }
+
+        $order = Mage::getModel('sales/order')->load($payment->getParentId());
+
+        return $order->getId() ? $order : null;
+    }
+
+    /**
+     * [vs main] MySQL advisory lock to serialize concurrent saveOrder for same Bold public order id.
+     *
+     * @param string $publicOrderId
+     * @return bool
+     */
+    public static function acquireLock($publicOrderId)
+    {
+        $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
+        $lockName = 'bold_checkout_place_' . md5($publicOrderId);
+        $result = $connection->fetchOne(
+            'SELECT GET_LOCK(?, 10)',
+            array($lockName)
+        );
+
+        return (int) $result === 1;
+    }
+
+    /**
+     * @param string|null $publicOrderId
+     * @return void
+     */
+    public static function releaseLock($publicOrderId = null)
+    {
+        $publicOrderId = $publicOrderId ?: self::$heldLockPublicId;
+        if (!$publicOrderId) {
+            return;
+        }
+
+        $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
+        $lockName = 'bold_checkout_place_' . md5($publicOrderId);
+        $connection->query('SELECT RELEASE_LOCK(?)', array($lockName));
+
+        if (self::$heldLockPublicId === $publicOrderId) {
+            self::$heldLockPublicId = null;
+        }
+    }
+
+    /**
+     * Core predispatch decision for SaveOrderObserver (standard checkout).
+     *
+     * @return array{action:string,order?:Mage_Sales_Model_Order,message?:string}
+     */
+    public static function evaluatePlacementRequest()
+    {
+        self::logStep(3, 'PlacementGuard::evaluatePlacementRequest');
+
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+
+        return self::evaluatePlacementRequestForQuote(
+            $session,
+            $session->getQuote(),
+            self::getEpsOrderIdFromRequest(),
+            Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId()
+        );
+    }
+
+    /**
+     * Testable predispatch evaluation with injectable session/quote.
+     *
+     * @param Mage_Checkout_Model_Session $session
+     * @param Mage_Sales_Model_Quote|null $quote
+     * @param string|null $epsOrderId
+     * @param string|null $publicOrderId
+     * @return array{action:string,order?:Mage_Sales_Model_Order,message?:string}
+     */
+    public static function evaluatePlacementRequestForQuote(
+        Mage_Checkout_Model_Session $session,
+        $quote,
+        $epsOrderId = null,
+        $publicOrderId = null,
+        $phase = 'predispatch'
+    ) {
+        $baseContext = self::buildPlacementContext($quote, $publicOrderId, $epsOrderId, $session);
+        self::logPlacementCheck($phase, 'start', 'evaluating', $baseContext);
+
+        if (!$quote || !$quote->getId()) {
+            self::logDupStep(3, 'quote_exists', 'block', 'missing_quote');
+            self::logPlacementCheck($phase, 'quote_exists', 'block', array('reason' => 'missing_quote'));
+
+            return array(
+                'action' => 'block',
+                'message' => Mage::helper('checkout')->__('Your shopping cart could not be found.'),
+            );
+        }
+
+        if ($epsOrderId) {
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::assertWalletEpsOrderIdBelongsToSession(
+                $epsOrderId
+            );
+        }
+
+        self::logDupStep(3, 'quote_exists', 'pass', 'quote_id=' . (int) $quote->getId());
+
+        if (!$quote->getIsActive()) {
+            $existingOrder = self::findOrderByQuoteId($quote->getId());
+            self::logDupStep(
+                3,
+                'quote_active',
+                'inactive',
+                'existing_order=' . ($existingOrder ? $existingOrder->getIncrementId() : 'none')
+            );
+            self::logPlacementCheck($phase, 'quote_active', 'inactive', array(
+                'existing_order_id' => $existingOrder ? (int) $existingOrder->getId() : null,
+                'existing_increment_id' => $existingOrder ? $existingOrder->getIncrementId() : null,
+            ));
+
+            if ($existingOrder) {
+                self::logDupStep(
+                    3,
+                    'quote_active',
+                    'duplicate',
+                    'success_existing order=' . $existingOrder->getIncrementId()
+                );
+                $result = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::buildSuccessExistingEvaluation(
+                    $existingOrder,
+                    $quote,
+                    'inactive_quote'
+                );
+                self::logPlacementCheck($phase, 'inactive_quote_ownership', $result['action'], array(
+                    'context' => 'inactive_quote',
+                    'existing_increment_id' => $existingOrder->getIncrementId(),
+                ));
+
+                return $result;
+            }
+
+            return array(
+                'action' => 'block',
+                'message' => Mage::helper('checkout')->__('Your shopping cart is no longer active.'),
+            );
+        }
+
+        self::logDupStep(3, 'quote_active', 'pass', 'quote_id=' . (int) $quote->getId());
+        self::logPlacementCheck($phase, 'quote_active', 'pass', array('quote_id' => (int) $quote->getId()));
+
+        if ($session->getData(self::SESSION_PLACEMENT_FLAG)) {
+            self::logDupStep(3, 'session_placement_flag', 'block_in_progress');
+            self::logPlacementCheck($phase, 'session_placement_flag', 'block_in_progress', array(
+                'flag' => self::SESSION_PLACEMENT_FLAG,
+            ));
+
+            return array(
+                'action' => 'block_in_progress',
+                'message' => Mage::helper('checkout')->__('Your order is already being placed. Please wait.'),
+            );
+        }
+
+        self::logDupStep(3, 'session_placement_flag', 'pass');
+        self::logPlacementCheck($phase, 'session_placement_flag', 'pass');
+
+        if ($publicOrderId) {
+            $existingOrder = self::findOrderByPublicId($publicOrderId);
+            self::logDupStep(
+                3,
+                'public_order_id',
+                $existingOrder ? 'duplicate' : 'not_found',
+                'public_id=' . $publicOrderId
+                . ($existingOrder ? ' order=' . $existingOrder->getIncrementId() : '')
+            );
+            self::logPlacementCheck($phase, 'public_order_id_lookup', $existingOrder ? 'found' : 'not_found', array(
+                'public_order_id' => $publicOrderId,
+                'existing_increment_id' => $existingOrder ? $existingOrder->getIncrementId() : null,
+            ));
+
+            if ($existingOrder) {
+                self::logDuplicateOrderAttempt($publicOrderId, 'predispatch');
+                self::logDupStep(
+                    3,
+                    'public_order_id',
+                    'duplicate_success_existing',
+                    'order=' . $existingOrder->getIncrementId()
+                );
+
+                $result = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::buildSuccessExistingEvaluation(
+                    $existingOrder,
+                    $quote,
+                    'public_order_id'
+                );
+                self::logPlacementCheck($phase, 'public_order_id_ownership', $result['action'], array(
+                    'context' => 'public_order_id',
+                ));
+
+                return $result;
+            }
+
+            $lockAcquired = self::acquireLock($publicOrderId);
+            self::logDupStep(
+                3,
+                'mysql_get_lock',
+                $lockAcquired ? 'acquired' : 'failed',
+                'public_id=' . $publicOrderId
+            );
+            self::logPlacementCheck($phase, 'mysql_get_lock', $lockAcquired ? 'acquired' : 'failed', array(
+                'public_order_id' => $publicOrderId,
+            ));
+
+            if (!$lockAcquired) {
+                return array(
+                    'action' => 'block_in_progress',
+                    'message' => Mage::helper('checkout')->__('Your order is already being placed. Please wait.'),
+                );
+            }
+
+            self::$heldLockPublicId = $publicOrderId;
+
+            $existingOrder = self::findOrderByPublicId($publicOrderId);
+            self::logDupStep(
+                3,
+                'public_order_id_after_lock',
+                $existingOrder ? 'duplicate' : 'not_found',
+                'public_id=' . $publicOrderId
+                . ($existingOrder ? ' order=' . $existingOrder->getIncrementId() : '')
+            );
+            self::logPlacementCheck($phase, 'public_order_id_lookup_after_lock', $existingOrder ? 'found' : 'not_found', array(
+                'public_order_id' => $publicOrderId,
+                'existing_increment_id' => $existingOrder ? $existingOrder->getIncrementId() : null,
+            ));
+
+            if ($existingOrder) {
+                self::releaseLock();
+                self::logDupStep(
+                    3,
+                    'public_order_id_after_lock',
+                    'duplicate_success_existing',
+                    'order=' . $existingOrder->getIncrementId()
+                );
+
+                $result = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::buildSuccessExistingEvaluation(
+                    $existingOrder,
+                    $quote,
+                    'public_order_id_after_lock'
+                );
+                self::logPlacementCheck($phase, 'public_order_id_ownership', $result['action'], array(
+                    'context' => 'public_order_id_after_lock',
+                ));
+
+                return $result;
+            }
+        } else {
+            self::logDupStep(3, 'public_order_id', 'skipped', 'no_public_id');
+            self::logPlacementCheck($phase, 'public_order_id_lookup', 'skipped', array('reason' => 'no_public_order_id'));
+        }
+
+        if ($epsOrderId) {
+            $existingOrder = self::findOrderByEpsOrderId($epsOrderId);
+            self::logDupStep(
+                3,
+                'eps_order_id',
+                $existingOrder ? 'duplicate' : 'not_found',
+                'eps_id=' . $epsOrderId
+                . ($existingOrder ? ' order=' . $existingOrder->getIncrementId() : '')
+            );
+            self::logPlacementCheck($phase, 'eps_order_id_lookup', $existingOrder ? 'found' : 'not_found', array(
+                'eps_order_id' => $epsOrderId,
+                'existing_increment_id' => $existingOrder ? $existingOrder->getIncrementId() : null,
+            ));
+
+            if ($existingOrder) {
+                self::releaseLock();
+                self::logDupStep(
+                    3,
+                    'eps_order_id',
+                    'duplicate_success_existing',
+                    'order=' . $existingOrder->getIncrementId()
+                );
+
+                $result = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::buildSuccessExistingEvaluation(
+                    $existingOrder,
+                    $quote,
+                    'eps_order_id'
+                );
+                self::logPlacementCheck($phase, 'eps_order_id_ownership', $result['action'], array(
+                    'context' => 'eps_order_id',
+                ));
+
+                return $result;
+            }
+        } else {
+            self::logDupStep(3, 'eps_order_id', 'skipped', 'no_eps_id');
+            self::logPlacementCheck($phase, 'eps_order_id_lookup', 'skipped', array('reason' => 'no_eps_order_id'));
+        }
+
+        $session->setData(self::SESSION_PLACEMENT_FLAG, 1);
+        self::logDupStep(3, 'final', 'allow', 'placement_flag_set');
+        self::logPlacementCheck($phase, 'final', 'allow', array('placement_flag_set' => true));
+
+        return array('action' => 'allow');
+    }
+
+    /**
+     * @param Mage_Sales_Model_Order $order
+     * @return void
+     */
+    public static function prepareCheckoutSessionForExistingOrder(Mage_Sales_Model_Order $order)
+    {
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $session->setLastQuoteId($order->getQuoteId());
+        $session->setLastSuccessQuoteId($order->getQuoteId());
+        $session->setLastOrderId($order->getId());
+        $session->setLastRealOrderId($order->getIncrementId());
+        $session->setRedirectUrl(null);
+    }
+
+    /**
+     * [vs main] Duplicate saveOrder: return JSON success + redirect (no second Magento order).
+     *
+     * @param Mage_Core_Controller_Varien_Action $controller
+     * @param Mage_Sales_Model_Order $order
+     * @return void
+     */
+    public static function respondWithExistingOrderSuccess($controller, Mage_Sales_Model_Order $order)
+    {
+        self::prepareCheckoutSessionForExistingOrder($order);
+        self::clearPlacementState();
+
+        /** @var Mage_Checkout_Model_Session $checkoutSession */
+        $checkoutSession = Mage::getSingleton('checkout/session');
+        $redirectUrl = $checkoutSession->getRedirectUrl();
+        if (!$redirectUrl) {
+            $redirectUrl = Mage::getUrl('checkout/onepage/success');
+        }
+
+        $result = array(
+            'success' => true,
+            'error' => false,
+            'redirect' => $redirectUrl,
+        );
+
+        $controller->getResponse()
+            ->clearHeaders()
+            ->setHeader('Content-type', 'application/json', true)
+            ->setBody(Mage::helper('core')->jsonEncode($result));
+
+        $controller->setFlag(
+            '',
+            Mage_Core_Controller_Varien_Action::FLAG_NO_DISPATCH,
+            true
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public static function clearPlacementState()
+    {
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $session->unsetData(self::SESSION_PLACEMENT_FLAG);
+        self::releaseLock();
+    }
+
+    /**
+     * @param string $message
+     * @throws Mage_Core_Exception
+     * @return void
+     */
+    public static function blockPlacement($message)
+    {
+        Mage::throwException($message);
+    }
+
+    /**
+     * Second line of defense during order submission.
+     *
+     * @param Mage_Sales_Model_Quote $quote
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    public static function assertQuoteCanSubmit(Mage_Sales_Model_Quote $quote)
+    {
+        self::logStep(7, 'PlacementGuard::assertQuoteCanSubmit quote_id=' . (int) $quote->getId());
+
+        $phase = 'assert_submit';
+        /** @var Mage_Checkout_Model_Session $session */
+        $session = Mage::getSingleton('checkout/session');
+        $publicOrderId = Bold_CheckoutPaymentBooster_Service_Bold::getPublicOrderId();
+        $epsOrderId = self::getEpsOrderIdFromRequest();
+
+        if ($epsOrderId) {
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::assertWalletEpsOrderIdBelongsToSession(
+                $epsOrderId
+            );
+        }
+
+        self::logPlacementCheck(
+            $phase,
+            'start',
+            'evaluating',
+            self::buildPlacementContext($quote, $publicOrderId, $epsOrderId, $session)
+        );
+
+        $alreadyUsedMessage = Mage::helper('checkout')->__(
+            'This Bold payment has already been used to place an order.'
+        );
+
+        if ($publicOrderId) {
+            $existingOrder = self::findOrderByPublicId($publicOrderId);
+            self::logDupStep(
+                7,
+                'public_order_id',
+                $existingOrder ? 'duplicate' : 'not_found',
+                'public_id=' . $publicOrderId
+                . ($existingOrder ? ' order=' . $existingOrder->getIncrementId() : '')
+            );
+            self::logPlacementCheck($phase, 'public_order_id_lookup', $existingOrder ? 'found' : 'not_found', array(
+                'public_order_id' => $publicOrderId,
+                'existing_increment_id' => $existingOrder ? $existingOrder->getIncrementId() : null,
+            ));
+
+            if ($existingOrder) {
+                self::assertExistingOrderBlocksPlacement($existingOrder, $quote, $publicOrderId, 'assert_public_order_id', $alreadyUsedMessage, $phase);
+            }
+        } else {
+            self::logDupStep(7, 'public_order_id', 'skipped', 'no_public_id');
+            self::logPlacementCheck($phase, 'public_order_id_lookup', 'skipped', array('reason' => 'no_public_order_id'));
+        }
+
+        if ($epsOrderId) {
+            $existingOrder = self::findOrderByEpsOrderId($epsOrderId);
+            self::logDupStep(
+                7,
+                'eps_order_id',
+                $existingOrder ? 'duplicate' : 'not_found',
+                'eps_id=' . $epsOrderId
+                . ($existingOrder ? ' order=' . $existingOrder->getIncrementId() : '')
+            );
+            self::logPlacementCheck($phase, 'eps_order_id_lookup', $existingOrder ? 'found' : 'not_found', array(
+                'eps_order_id' => $epsOrderId,
+                'existing_increment_id' => $existingOrder ? $existingOrder->getIncrementId() : null,
+            ));
+
+            if ($existingOrder) {
+                self::assertExistingOrderBlocksPlacement($existingOrder, $quote, $epsOrderId, 'assert_eps_order_id', $alreadyUsedMessage, $phase);
+            }
+        } else {
+            self::logDupStep(7, 'eps_order_id', 'skipped', 'no_eps_id');
+            self::logPlacementCheck($phase, 'eps_order_id_lookup', 'skipped', array('reason' => 'no_eps_order_id'));
+        }
+
+        if (!$quote->getIsActive()) {
+            $existingOrder = self::findOrderByQuoteId($quote->getId());
+            self::logDupStep(
+                7,
+                'quote_active',
+                'inactive',
+                'existing_order=' . ($existingOrder ? $existingOrder->getIncrementId() : 'none')
+            );
+            self::logPlacementCheck($phase, 'quote_active', 'inactive', array(
+                'existing_order_id' => $existingOrder ? (int) $existingOrder->getId() : null,
+                'existing_increment_id' => $existingOrder ? $existingOrder->getIncrementId() : null,
+            ));
+
+            if ($existingOrder) {
+                self::logDupStep(
+                    7,
+                    'quote_active',
+                    'duplicate',
+                    'block order=' . $existingOrder->getIncrementId()
+                );
+                $alreadyPlacedMessage = Mage::helper('checkout')->__('This order has already been placed.');
+                self::assertExistingOrderBlocksPlacement(
+                    $existingOrder,
+                    $quote,
+                    (string) $quote->getId(),
+                    'assert_inactive_quote',
+                    $alreadyPlacedMessage,
+                    $phase
+                );
+            }
+        } else {
+            self::logDupStep(7, 'quote_active', 'pass', 'quote_id=' . (int) $quote->getId());
+            self::logPlacementCheck($phase, 'quote_active', 'pass', array('quote_id' => (int) $quote->getId()));
+        }
+
+        self::logDupStep(7, 'final', 'allow');
+        self::logPlacementCheck($phase, 'final', 'allow');
+    }
+
+    /**
+     * @param Mage_Sales_Model_Order $existingOrder
+     * @param Mage_Sales_Model_Quote $quote
+     * @param string $logId
+     * @param string $context
+     * @param string $message
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    private static function assertExistingOrderBlocksPlacement(
+        Mage_Sales_Model_Order $existingOrder,
+        Mage_Sales_Model_Quote $quote,
+        $logId,
+        $context,
+        $message,
+        $phase = 'assert_submit'
+    ) {
+        $belongs = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::orderBelongsToCheckoutSession(
+            $existingOrder,
+            $quote
+        );
+
+        self::logDupStep(
+            7,
+            'session_ownership',
+            $belongs ? 'owned' : 'foreign',
+            'context=' . $context . ' order=' . $existingOrder->getIncrementId()
+        );
+
+        self::logPlacementCheck($phase, 'session_ownership', $belongs ? 'owned' : 'foreign', array(
+            'context' => $context,
+            'existing_increment_id' => $existingOrder->getIncrementId(),
+            'existing_quote_id' => (int) $existingOrder->getQuoteId(),
+            'quote_id' => (int) $quote->getId(),
+        ));
+
+        if (!$belongs) {
+            self::logDupStep(7, 'session_ownership', 'block', 'foreign_session context=' . $context);
+            self::logDuplicateOrderAttempt($logId, 'assert_rejected_' . $context);
+        }
+
+        self::logDupStep(
+            7,
+            $context,
+            'block',
+            $belongs ? 'duplicate_same_session' : 'duplicate_foreign_session'
+        );
+
+        self::logPlacementCheck($phase, $context, 'block', array(
+            'reason' => $belongs ? 'duplicate_same_session' : 'duplicate_foreign_session',
+        ));
+
+        self::blockPlacement($message);
+    }
+}

--- a/Service/Order/Update.php
+++ b/Service/Order/Update.php
@@ -36,7 +36,7 @@ class Bold_CheckoutPaymentBooster_Service_Order_Update
         );
 
         if (isset($response->errors) || isset($response->error)) {
-            $message = isset($updateResponse->error) ? json_encode($updateResponse->error) : 'n/a';
+            $message = isset($response->error) ? json_encode($response->error) : 'n/a';
             Mage::throwException('Cannot update order state, order id: ' . $order->getId() . ', error: ' . $message);
         }
     }

--- a/Service/Rsa/Connect.php
+++ b/Service/Rsa/Connect.php
@@ -1,11 +1,31 @@
 <?php
 
+/**
+ * Registers Magento as Bold's RSA (remote state authority) callback target.
+ *
+ * The shared secret generated here is used by Bold to sign inbound payment
+ * webhooks; Magento verifies those signatures in Model/Router::authorize().
+ */
 class Bold_CheckoutPaymentBooster_Service_Rsa_Connect
 {
     const URL = 'checkout/shop/{{shopId}}/rsa_config';
 
+    /** Bold endpoint that confirms rsa_config was applied before Magento persists locally. */
+    const CHECK_SHARED_URL = 'checkout/shop/{{shopId}}/rsa_config/checkShared';
+
+    /** Bold error code when RSA has never been registered (first-time setup). */
+    const CODE_RSA_NOT_CONFIGURED = '02-89';
+
+    /** Delay between checkShared retries while Bold propagates the new secret. */
+    const CHECK_SHARED_RETRY_DELAY_US = 1000000;
+
+    /** Max checkShared attempts (initial + retries ≈ 3s propagation window). */
+    const CHECK_SHARED_MAX_ATTEMPTS = 4;
+
+    const REGISTRY_ROTATION_LOCK_PREFIX = 'bold_checkout_rsa_rotating_';
+
     /**
-     * Set RSA configuration.
+     * Set RSA configuration (legacy entry point).
      *
      * @param int $websiteId
      * @return void
@@ -13,21 +33,394 @@ class Bold_CheckoutPaymentBooster_Service_Rsa_Connect
      */
     public static function setRsaConfig($websiteId)
     {
-        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
-        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
-        Bold_CheckoutPaymentBooster_Service_BoldClient::delete(self::URL, $websiteId);
-        $sharedSecret = self::generateSharedSecret();
-        $body = [
-            'url' => Mage::app()->getStore()->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB) . 'rest/V1',
-            'shared_secret' => $sharedSecret,
-        ];
-        $result = Bold_CheckoutPaymentBooster_Service_BoldClient::post(self::URL, $websiteId, $body);
-        $message = isset($result->errors[0]->message) ? $result->errors[0]->message : null;
-        if (!$message) {
-            $config->setSharedSecret($sharedSecret, $websiteId);
+        self::registerRsaConfig($websiteId, true);
+    }
+
+    /**
+     * Register RSA configuration with Bold.
+     *
+     * @param int $websiteId
+     * @param bool $force When true, always register even if rotation is not required.
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    public static function registerRsaConfig($websiteId, $force = false)
+    {
+        // Routine admin saves should not rotate the secret — only first setup,
+        // API token change, or an explicit Rotate Shared Key should re-register RSA.
+        if (!$force && !Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::shouldRotateRsa($websiteId, false)) {
+            Mage::log(
+                'RSA registration skipped (no rotation trigger)',
+                Zend_Log::DEBUG,
+                Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME
+            );
             return;
         }
-        Mage::throwException($result->errors[0]->message);
+
+        if (!self::acquireRotationLock($websiteId)) {
+            Mage::throwException(
+                'RSA rotation is already in progress for this website. Please wait a moment and try again.'
+            );
+        }
+
+        try {
+            self::executeRsaRegistration($websiteId);
+        } finally {
+            self::releaseRotationLock($websiteId);
+        }
+    }
+
+    /**
+     * @param int $websiteId
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    private static function executeRsaRegistration($websiteId)
+    {
+        self::assertShopIdPresent($websiteId);
+
+        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        $previousSharedSecret = $config->getSharedSecret($websiteId);
+        $callbackUrl = self::getRestCallbackUrl($websiteId);
+        // Keep the new secret in memory until Bold confirms PATCH/POST and checkShared
+        // succeeds — Magento must not persist locally until both sides agree.
+        $sharedSecret = self::generateSharedSecret();
+        $body = [
+            'url' => $callbackUrl,
+            'shared_secret' => $sharedSecret,
+        ];
+
+        // PATCH updates RSA in place (Adobe Commerce pattern). Avoids DELETE-before-POST,
+        // which left Bold without RSA when POST failed (shared-secret drift).
+        $result = Bold_CheckoutPaymentBooster_Service_BoldClient::patch(self::URL, $websiteId, $body);
+        if (self::isRsaNotConfigured($result)) {
+            $result = Bold_CheckoutPaymentBooster_Service_BoldClient::post(self::URL, $websiteId, $body);
+        }
+        if (!self::isRegistrationSuccess($result)) {
+            $message = self::getRegistrationErrorMessage($result);
+            Mage::throwException(
+                $message
+                    ? 'RSA registration failed: ' . $message . ' Inbound payment webhooks will not work until you save again or use Rotate Shared Key.'
+                    : 'RSA registration failed. Inbound payment webhooks will not work until you save again or use Rotate Shared Key.'
+            );
+        }
+
+        if ($config->isCheckSharedEnabled($websiteId)
+            && !self::verifySharedSecretWithBoldCheckShared($websiteId, $sharedSecret, $callbackUrl)
+        ) {
+            if ($previousSharedSecret) {
+                self::attemptRestorePreviousRsaConfig($websiteId, $previousSharedSecret, $callbackUrl);
+            }
+
+            Mage::throwException(self::getVerificationFailureMessage((bool)$previousSharedSecret));
+        }
+
+        $config->setSharedSecret($sharedSecret, $websiteId);
+    }
+
+    /**
+     * Ask Bold checkout to confirm rsa_config matches the proposed url + shared secret.
+     *
+     * @param int $websiteId
+     * @param string $sharedSecret
+     * @param string $callbackUrl
+     * @return bool
+     */
+    public static function verifySharedSecretWithBoldCheckShared($websiteId, $sharedSecret, $callbackUrl)
+    {
+        $body = [
+            'url' => $callbackUrl,
+            'shared_secret' => $sharedSecret,
+        ];
+
+        $lastResult = null;
+        for ($attempt = 1; $attempt <= self::CHECK_SHARED_MAX_ATTEMPTS; $attempt++) {
+            if ($attempt > 1) {
+                usleep(self::CHECK_SHARED_RETRY_DELAY_US);
+            }
+
+            $lastResult = Bold_CheckoutPaymentBooster_Service_BoldClient::post(
+                self::CHECK_SHARED_URL,
+                $websiteId,
+                $body
+            );
+
+            if (self::isCheckSharedSuccess($lastResult)) {
+                Mage::log(
+                    'RSA shared secret verified via Bold checkShared for website '
+                    . $websiteId
+                    . ($attempt > 1 ? ' (attempt ' . $attempt . ')' : '')
+                    . '.',
+                    Zend_Log::INFO,
+                    Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME
+                );
+
+                return true;
+            }
+        }
+
+        self::logCheckSharedFailure($websiteId, $lastResult);
+
+        return false;
+    }
+
+    /**
+     * @param stdClass|null $result
+     * @return bool
+     */
+    public static function isCheckSharedSuccess($result)
+    {
+        if (!$result || !is_object($result)) {
+            return false;
+        }
+
+        if (!isset($result->data)) {
+            return false;
+        }
+
+        $data = $result->data;
+        if ($data === true || $data === 1 || $data === '1') {
+            return true;
+        }
+
+        if ($data === false || $data === 0 || $data === '0') {
+            return false;
+        }
+
+        return (int)$data === 1;
+    }
+
+    /**
+     * Serialize RSA rotations per website across concurrent admin requests.
+     *
+     * @param int $websiteId
+     * @return bool
+     */
+    public static function acquireRotationLock($websiteId)
+    {
+        $registryKey = self::REGISTRY_ROTATION_LOCK_PREFIX . (int)$websiteId;
+        if (Mage::registry($registryKey)) {
+            return false;
+        }
+
+        Mage::register($registryKey, true);
+
+        try {
+            $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
+            $lockName = 'bold_checkout_rsa_rotate_' . (int)$websiteId;
+            $result = $connection->fetchOne(
+                'SELECT GET_LOCK(?, 10)',
+                array($lockName)
+            );
+            if ((int)$result !== 1) {
+                Mage::unregister($registryKey);
+                return false;
+            }
+        } catch (Exception $exception) {
+            Mage::unregister($registryKey);
+            throw $exception;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param int $websiteId
+     * @return void
+     */
+    public static function releaseRotationLock($websiteId)
+    {
+        $registryKey = self::REGISTRY_ROTATION_LOCK_PREFIX . (int)$websiteId;
+
+        try {
+            $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
+            $lockName = 'bold_checkout_rsa_rotate_' . (int)$websiteId;
+            $connection->query('SELECT RELEASE_LOCK(?)', array($lockName));
+        } catch (Exception $exception) {
+            Mage::logException($exception);
+        }
+
+        if (Mage::registry($registryKey)) {
+            Mage::unregister($registryKey);
+        }
+    }
+
+    /**
+     * Build the Magento REST callback URL for RSA registration.
+     *
+     * @param int $websiteId
+     * @return string
+     */
+    public static function getRestCallbackUrl($websiteId)
+    {
+        // Use the website being configured, not the admin user's current store scope.
+        $defaultStore = Mage::app()->getWebsite($websiteId)->getDefaultStore();
+        $baseUrl = $defaultStore->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, true);
+        if (!$baseUrl || $baseUrl === 'http://' || $baseUrl === 'https://') {
+            $baseUrl = $defaultStore->getBaseUrl(Mage_Core_Model_Store::URL_TYPE_LINK, false);
+        }
+
+        return rtrim($baseUrl, '/') . '/rest/V1';
+    }
+
+    /**
+     * Require a persisted shop_id before RSA calls.
+     *
+     * @param int $websiteId
+     * @return void
+     * @throws Mage_Core_Exception
+     */
+    public static function assertShopIdPresent($websiteId)
+    {
+        /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        // Read persisted shop_id only — ShopInfo::getShopId() would auto-fetch and
+        // mask a failed saveShopInfo, producing checkout/shop//rsa_config requests.
+        $shopId = $config->getShopId($websiteId);
+        if (!$shopId) {
+            Mage::throwException(
+                'Bold shop ID is missing. Save your API token first so shop info can be retrieved before RSA registration.'
+            );
+        }
+    }
+
+    /**
+     * @param bool $hadPreviousSecret
+     * @return string
+     */
+    public static function getVerificationFailureMessage($hadPreviousSecret)
+    {
+        if ($hadPreviousSecret) {
+            return 'RSA registration verification failed: Bold could not confirm the new shared secret. '
+                . 'Your previous RSA configuration was restored on Bold. '
+                . 'Inbound payment webhooks were not changed. '
+                . 'Check var/log/bold_checkout_payment_booster.log and try Rotate Shared Key again.';
+        }
+
+        return 'RSA registration verification failed: Bold could not confirm the new shared secret. '
+            . 'Inbound payment webhooks will not work until you save again or use Rotate Shared Key. '
+            . 'Check var/log/bold_checkout_payment_booster.log.';
+    }
+
+    /**
+     * @param int $websiteId
+     * @param stdClass|null $result
+     * @return void
+     */
+    private static function logCheckSharedFailure($websiteId, $result)
+    {
+        $detail = '';
+        if ($result && is_object($result) && isset($result->data)) {
+            $detail = ' checkShared=' . json_encode($result->data);
+        } elseif ($result && is_object($result)) {
+            $detail = ' response=' . json_encode($result);
+        }
+
+        Mage::log(
+            'RSA checkShared verification failed for website ' . $websiteId . '.' . $detail,
+            Zend_Log::WARN,
+            Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME
+        );
+    }
+
+    /**
+     * @param int $websiteId
+     * @param string $previousSharedSecret
+     * @param string $callbackUrl
+     * @return void
+     */
+    private static function attemptRestorePreviousRsaConfig($websiteId, $previousSharedSecret, $callbackUrl)
+    {
+        $body = [
+            'url' => $callbackUrl,
+            'shared_secret' => $previousSharedSecret,
+        ];
+        $result = Bold_CheckoutPaymentBooster_Service_BoldClient::patch(self::URL, $websiteId, $body);
+        if (self::isRegistrationSuccess($result)) {
+            Mage::log(
+                'RSA rolled back to previous shared secret after checkShared verification failure',
+                Zend_Log::WARN,
+                Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME
+            );
+            return;
+        }
+
+        Mage::log(
+            'RSA rollback failed after checkShared verification failure: ' . self::getRegistrationErrorMessage($result),
+            Zend_Log::ERR,
+            Bold_CheckoutPaymentBooster_Model_Config::LOG_FILE_NAME
+        );
+    }
+
+    /**
+     * @param stdClass|null $result
+     * @return bool
+     */
+    public static function isRegistrationSuccess($result)
+    {
+        if (!$result || !is_object($result)) {
+            return false;
+        }
+
+        if (isset($result->errors) && is_array($result->errors) && count($result->errors) > 0) {
+            return false;
+        }
+
+        if (isset($result->error)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Bold returns 02-89 when RSA has not been registered yet; POST is required once.
+     *
+     * @param stdClass|null $result
+     * @return bool
+     */
+    public static function isRsaNotConfigured($result)
+    {
+        if (!$result || !is_object($result) || !isset($result->errors[0])) {
+            return false;
+        }
+
+        $error = $result->errors[0];
+        if (is_object($error) && isset($error->code)) {
+            return (string)$error->code === self::CODE_RSA_NOT_CONFIGURED;
+        }
+
+        if (is_array($error) && isset($error['code'])) {
+            return (string)$error['code'] === self::CODE_RSA_NOT_CONFIGURED;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param stdClass|null $result
+     * @return string
+     */
+    public static function getRegistrationErrorMessage($result)
+    {
+        if (!$result || !is_object($result)) {
+            return '';
+        }
+
+        if (isset($result->errors[0]->message)) {
+            return (string)$result->errors[0]->message;
+        }
+
+        if (isset($result->error_description)) {
+            return (string)$result->error_description;
+        }
+
+        if (isset($result->error->message)) {
+            return (string)$result->error->message;
+        }
+
+        return '';
     }
 
     /**

--- a/Service/ShopInfo.php
+++ b/Service/ShopInfo.php
@@ -37,7 +37,9 @@ class Bold_CheckoutPaymentBooster_Service_ShopInfo
     {
         /** @var Bold_CheckoutPaymentBooster_Model_Config $config */
         $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
-        $config->setShopId(null, $websiteId);
+
+        // Do not clear shop_id before fetch. A failed shops/v1/info call used to leave
+        // shop_id empty while RSA registration still ran in the next observer.
         $apiToken = $config->getApiToken($websiteId);
         $headers = [
             'Authorization: Bearer ' . $apiToken,

--- a/controllers/Adminhtml/LogsController.php
+++ b/controllers/Adminhtml/LogsController.php
@@ -3,7 +3,8 @@ class Bold_CheckoutPaymentBooster_Adminhtml_LogsController extends Mage_Adminhtm
 {
     protected function _isAllowed()
     {
-        return true;
+        // Restrict log export to admins who can edit Bold configuration.
+        return Mage::getSingleton('admin/session')->isAllowed('system/config');
     }
 
     public function exportAction()

--- a/controllers/Adminhtml/RsaController.php
+++ b/controllers/Adminhtml/RsaController.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Manual RSA recovery when inbound Bold webhooks fail HMAC verification.
+ */
+class Bold_CheckoutPaymentBooster_Adminhtml_RsaController extends Mage_Adminhtml_Controller_Action
+{
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/config');
+    }
+
+    /**
+     * Rotate shared key with Bold and save locally after Bold checkShared verification.
+     */
+    public function rotateAction()
+    {
+        $this->executeSharedSecretRotation();
+    }
+
+    /**
+     * @return void
+     */
+    private function executeSharedSecretRotation()
+    {
+        try {
+            $websiteId = $this->resolveWebsiteId();
+            if ($websiteId === 0) {
+                $this->_getSession()->addError(
+                    Mage::helper('core')->__('Please select a website scope before rotating the shared key.')
+                );
+                $this->_redirectReferer();
+                return;
+            }
+
+            Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::run(
+                $websiteId,
+                array('force_rsa' => true)
+            );
+
+            $this->_getSession()->addSuccess(
+                Mage::helper('core')->__('Shared key was rotated and saved with Bold successfully.')
+            );
+        } catch (Exception $exception) {
+            Mage::logException($exception);
+            $this->_getSession()->addError($exception->getMessage());
+        }
+
+        $this->_redirectReferer();
+    }
+
+    /**
+     * @return int
+     */
+    private function resolveWebsiteId()
+    {
+        $website = $this->getRequest()->getParam('website');
+        if ($website) {
+            try {
+                return (int)Mage::app()->getWebsite($website)->getId();
+            } catch (Exception $exception) {
+                Mage::logException($exception);
+            }
+        }
+
+        $store = $this->getRequest()->getParam('store');
+        if ($store) {
+            try {
+                return (int)Mage::app()->getStore($store)->getWebsiteId();
+            } catch (Exception $exception) {
+                Mage::logException($exception);
+            }
+        }
+
+        $referer = (string)$this->getRequest()->getServer('HTTP_REFERER');
+        if ($referer !== '') {
+            if (preg_match('#/website/([^/?#]+)#', $referer, $matches)) {
+                try {
+                    return (int)Mage::app()->getWebsite($matches[1])->getId();
+                } catch (Exception $exception) {
+                    Mage::logException($exception);
+                }
+            }
+
+            if (preg_match('#/store/([^/?#]+)#', $referer, $matches)) {
+                try {
+                    return (int)Mage::app()->getStore($matches[1])->getWebsiteId();
+                } catch (Exception $exception) {
+                    Mage::logException($exception);
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/controllers/ExpresspayController.php
+++ b/controllers/ExpresspayController.php
@@ -46,21 +46,18 @@ class Bold_CheckoutPaymentBooster_ExpresspayController extends Mage_Core_Control
             return;
         }
 
-        if ($quoteId !== '') {
-            /** @var Mage_Sales_Model_Quote $quote */
-            $quote = Mage::getModel('sales/quote')->load($quoteId);
-            $errorMessage = Mage::helper('core')->__('Invalid quote ID "%s".', $quoteId);
-        } else {
-            /** @var Mage_Sales_Model_Quote $quote */
-            $quote = Mage::getSingleton('checkout/session')->getQuote();
-            $errorMessage = Mage::helper('core')->__('Active quote not found.', $quoteId);
+        $quote = $this->loadCheckoutSessionQuoteForRequest($quoteId);
+        if ($quote === null) {
+            return;
         }
 
-        if ($quote->getId() === null) {
+        $recentEpsOrderId = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::getRecentWalletEpsOrderId(
+            (int) $quote->getId()
+        );
+        if ($recentEpsOrderId !== '') {
             $this->getResponse()
-                ->setHttpResponseCode(400)
                 ->setHeader('Content-Type', 'application/json')
-                ->setBody(json_encode(['error' => $errorMessage]));
+                ->setBody(json_encode(array('order_id' => $recentEpsOrderId)));
 
             return;
         }
@@ -110,9 +107,16 @@ class Bold_CheckoutPaymentBooster_ExpresspayController extends Mage_Core_Control
             return;
         }
 
+        $epsOrderId = (string) $result->data->order_id;
+        Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::registerWalletEpsOrderId($epsOrderId);
+        Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::rememberWalletEpsOrderCreate(
+            (int) $quote->getId(),
+            $epsOrderId
+        );
+
         $this->getResponse()
             ->setHeader('Content-Type', 'application/json')
-            ->setBody(json_encode(['order_id' => $result->data->order_id]));
+            ->setBody(json_encode(array('order_id' => $epsOrderId)));
     }
 
     /**
@@ -166,21 +170,12 @@ class Bold_CheckoutPaymentBooster_ExpresspayController extends Mage_Core_Control
             return;
         }
 
-        if ($quoteId !== '') {
-            /** @var Mage_Sales_Model_Quote $quote */
-            $quote = Mage::getModel('sales/quote')->load($quoteId);
-            $errorMessage = Mage::helper('core')->__('Invalid quote ID "%s".', $quoteId);
-        } else {
-            /** @var Mage_Sales_Model_Quote $quote */
-            $quote = Mage::getSingleton('checkout/session')->getQuote();
-            $errorMessage = Mage::helper('core')->__('Active quote not found.', $quoteId);
+        if (!$this->assertWalletOrderIdForRequest($orderId)) {
+            return;
         }
 
-        if ($quote->getId() === null) {
-            $this->getResponse()
-                ->setHttpResponseCode(400)
-                ->setBody(json_encode(['error' => $errorMessage]));
-
+        $quote = $this->loadCheckoutSessionQuoteForRequest($quoteId);
+        if ($quote === null) {
             return;
         }
 
@@ -272,6 +267,10 @@ class Bold_CheckoutPaymentBooster_ExpresspayController extends Mage_Core_Control
             return;
         }
 
+        if (!$this->assertWalletOrderIdForRequest($orderId)) {
+            return;
+        }
+
         $gatewayId = $this->getRequest()->getParam('gateway_id');
 
         if ($gatewayId === null) {
@@ -321,6 +320,59 @@ class Bold_CheckoutPaymentBooster_ExpresspayController extends Mage_Core_Control
         $this->getResponse()
             ->setHeader('Content-Type', 'application/json')
             ->setBody(json_encode($result->data));
+    }
+
+    /**
+     * @param string $orderId
+     * @return bool
+     */
+    private function assertWalletOrderIdForRequest($orderId)
+    {
+        try {
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::assertWalletEpsOrderIdBelongsToSession(
+                $orderId
+            );
+        } catch (Mage_Core_Exception $exception) {
+            $httpCode = ($exception->getCode()
+                === Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::EXCEPTION_QUOTE_ACCESS_DENIED)
+                ? 403
+                : 400;
+
+            $this->getResponse()
+                ->setHttpResponseCode($httpCode)
+                ->setHeader('Content-Type', 'application/json')
+                ->setBody(json_encode(array('error' => $exception->getMessage())));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string|null $quoteIdParam
+     * @return Mage_Sales_Model_Quote|null
+     */
+    private function loadCheckoutSessionQuoteForRequest($quoteIdParam)
+    {
+        try {
+            return Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::loadCheckoutSessionQuote(
+                $quoteIdParam
+            );
+        } catch (Mage_Core_Exception $exception) {
+            $message = $exception->getMessage();
+            $httpCode = ($exception->getCode()
+                === Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::EXCEPTION_QUOTE_ACCESS_DENIED)
+                ? 403
+                : 400;
+
+            $this->getResponse()
+                ->setHttpResponseCode($httpCode)
+                ->setHeader('Content-Type', 'application/json')
+                ->setBody(json_encode(array('error' => $message)));
+
+            return null;
+        }
     }
 
     /**

--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -15,16 +15,69 @@ class Bold_CheckoutPaymentBooster_IndexController extends Mage_Core_Controller_F
         if (!$this->_validateFormKey()) {
             return;
         }
+
         $quote = Mage::getSingleton('checkout/session')->getQuote();
         $cartData = Bold_CheckoutPaymentBooster_Service_Order_Hydrate_ExtractData::extractQuoteData($quote);
         $cartData['quote_currency_code'] = $quote->getQuoteCurrencyCode();
         $cartData['shipping_options'] = Bold_CheckoutPaymentBooster_Service_Order_Hydrate_ExtractData::getQuoteShippingOptions($quote);
-        $this->getResponse()->setBody(json_encode($cartData));
+        $this->getResponse()
+            ->setHeader('Content-type', 'application/json')
+            ->setBody(json_encode($cartData));
     }
 
+    /**
+     * Return current Bold checkout session tokens for client sync before Payments SDK init.
+     *
+     * @return void
+     */
+    public function getCheckoutSessionAction()
+    {
+        if (!$this->requirePostAjax() || !$this->validateFormKeyJson()) {
+            return;
+        }
+
+        /** @var Mage_Sales_Model_Quote $quote */
+        $quote = Mage::getSingleton('checkout/session')->getQuote();
+        if (!$quote || !$quote->getId()) {
+            $this->getResponse()
+                ->setHttpResponseCode(400)
+                ->setHeader('Content-Type', 'application/json')
+                ->setBody(json_encode(array(
+                    'error' => Mage::helper('checkout')->__('Your shopping cart could not be found.'),
+                )));
+
+            return;
+        }
+
+        try {
+            Bold_CheckoutPaymentBooster_Service_Bold::initBoldCheckoutData($quote);
+        } catch (Exception $e) {
+            Mage::log($e->getMessage(), Zend_Log::CRIT);
+            $this->getResponse()
+                ->setHttpResponseCode(500)
+                ->setHeader('Content-Type', 'application/json')
+                ->setBody(json_encode(array(
+                    'error' => Mage::helper('core')->__('Unable to initialize Bold checkout session.'),
+                )));
+
+            return;
+        }
+
+        /** @var Bold_CheckoutPaymentBooster_Block_Payment_Form_Base $block */
+        $block = Mage::getSingleton('core/layout')->createBlock('bold_checkout_payment_booster/payment_form_base');
+        $payload = $block->getCheckoutSessionPayload();
+
+        $this->getResponse()
+            ->setHeader('Content-Type', 'application/json')
+            ->setBody(Mage::helper('core')->jsonEncode($payload));
+    }
+
+    /**
+     * @return void
+     */
     public function getCartTotalsAction()
     {
-        if (!$this->_validateFormKey()) {
+        if (!$this->requirePostAjax() || !$this->validateFormKeyJson()) {
             return;
         }
 
@@ -45,9 +98,12 @@ class Bold_CheckoutPaymentBooster_IndexController extends Mage_Core_Controller_F
             ->setBody(json_encode($cartTotals));
     }
 
+    /**
+     * @return void
+     */
     public function getCartItemsAction()
     {
-        if (!$this->_validateFormKey()) {
+        if (!$this->requirePostAjax() || !$this->validateFormKeyJson()) {
             return;
         }
 
@@ -67,5 +123,38 @@ class Bold_CheckoutPaymentBooster_IndexController extends Mage_Core_Controller_F
         $this->getResponse()
             ->setHeader('Content-type', 'application/json')
             ->setBody(json_encode($quoteItems));
+    }
+
+    /**
+     * @return bool
+     */
+    private function requirePostAjax()
+    {
+        if (!$this->getRequest()->isPost() || !$this->getRequest()->isAjax()) {
+            $this->_forward('noroute');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    private function validateFormKeyJson()
+    {
+        if (!$this->_validateFormKey()) {
+            $this->getResponse()
+                ->setHttpResponseCode(403)
+                ->setHeader('Content-Type', 'application/json')
+                ->setBody(json_encode(array(
+                    'error' => Mage::helper('core')->__('Invalid form key.'),
+                )));
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/design/adminhtml/default/default/template/bold/checkout_payment_booster/system/config/button/rsa_action.phtml
+++ b/design/adminhtml/default/default/template/bold/checkout_payment_booster/system/config/button/rsa_action.phtml
@@ -1,0 +1,2 @@
+<?php echo $this->getButtonHtml(); ?>
+<?php echo $this->getActionScript(); ?>

--- a/design/frontend/base/default/template/bold/checkout_payment_booster/payment/form/base.phtml
+++ b/design/frontend/base/default/template/bold/checkout_payment_booster/payment/form/base.phtml
@@ -5,6 +5,12 @@
 ?>
 
 <script type="text/javascript">
+    if (typeof window.bold === 'undefined') {
+        window.bold = {};
+    }
+
+    window.bold.walletCheckoutConfig = <?php echo json_encode($this->getWalletCheckoutJsConfig()) ?>;
+
     /**
      * Bold Payments base class.
      */
@@ -16,6 +22,8 @@
         gatewayData: null,
         buildFastlaneInstanceInProgress: false,
         buildPaymentsInstanceInProgress: false,
+        syncCheckoutSessionPromise: null,
+        publicOrderId: '<?php echo $this->getPublicOrderID(); ?>',
         isAvailable: <?php echo $this->isAvailable(); ?>,
         groupLabel: '<?php echo $this->getGroupLabel() ?>',
         boldApiUrl: '<?php echo $this->getBoldApiUrl(); ?>',
@@ -351,11 +359,93 @@
             }
         },
         /**
+         * Sync Bold checkout session tokens from Magento before Payments SDK init.
+         *
+         * @returns {Promise<boolean>}
+         */
+        syncCheckoutSessionFromServer: function () {
+            if (this.syncCheckoutSessionPromise) {
+                return this.syncCheckoutSessionPromise;
+            }
+            const cfg = window.bold.walletCheckoutConfig;
+            if (!cfg || !cfg.getCheckoutSessionUrl) {
+                return Promise.resolve(false);
+            }
+            this.syncCheckoutSessionPromise = new Promise((resolve, reject) => {
+                new Ajax.Request(cfg.getCheckoutSessionUrl, {
+                    method: 'post',
+                    parameters: {form_key: cfg.formKey},
+                    requestHeaders: {Accept: 'application/json'},
+                    onSuccess: (response) => {
+                        try {
+                            resolve(this.applyCheckoutSessionPayload(JSON.parse(response.responseText)));
+                        } catch (e) {
+                            reject(e);
+                        }
+                    },
+                    onFailure: () => {
+                        reject(new Error('Failed to sync Bold checkout session'));
+                    },
+                    onComplete: () => {
+                        this.syncCheckoutSessionPromise = null;
+                    }
+                });
+            });
+            return this.syncCheckoutSessionPromise;
+        },
+        /**
+         * Apply server checkout session payload; reset Payments SDK when public_order_id rotates.
+         *
+         * @param {{}} payload
+         * @returns {boolean}
+         */
+        applyCheckoutSessionPayload: function (payload) {
+            if (!payload || !payload.public_order_id) {
+                return false;
+            }
+            const previousId = this.publicOrderId;
+            const rotated = !!(previousId && previousId !== payload.public_order_id);
+            this.publicOrderId = payload.public_order_id;
+            window.bold.publicOrderId = payload.public_order_id;
+            if (payload.jwt_token) {
+                this.jwtToken = payload.jwt_token;
+            }
+            if (payload.eps_auth_token) {
+                this.epsAuthToken = payload.eps_auth_token;
+            }
+            if (payload.bold_api_url) {
+                this.boldApiUrl = payload.bold_api_url;
+            }
+            if (payload.eps_gateway_id) {
+                this.epsGatewayId = payload.eps_gateway_id;
+            }
+            if (rotated) {
+                console.warn('[Bold] public_order_id rotated', previousId, '->', payload.public_order_id);
+                this.resetBoldPaymentsInstance();
+                if (window.bold.boldPaymentMethod) {
+                    window.bold.boldPaymentMethod.walletButtonsRendered = false;
+                }
+            }
+            return rotated;
+        },
+        applyBoldCheckoutSession: function (payload) {
+            return this.applyCheckoutSessionPayload(payload);
+        },
+        resetBoldPaymentsInstance: function () {
+            this.boldPaymentsInstance = null;
+            this.buildPaymentsInstanceInProgress = false;
+        },
+        /**
          * Load SPI SDK.
          *
          * @returns {Promise<void>}
          */
         getBoldPaymentsInstance: async function () {
+            try {
+                await this.syncCheckoutSessionFromServer();
+            } catch (e) {
+                console.warn('[Bold] Checkout session sync failed before Payments SDK init', e);
+            }
             if (this.boldPaymentsInstance) {
                 this.buildPaymentsInstanceInProgress = false;
                 return this.boldPaymentsInstance;
@@ -373,7 +463,7 @@
                 'eps_url': this.epsUrl,
                 'eps_bucket_url': this.epsStaticUrl,
                 'group_label': this.groupLabel,
-                'trace_id': '<?php echo $this->getPublicOrderID(); ?>',
+                'trace_id': this.publicOrderId,
                 'payment_gateways': [
                     {
                         'gateway_id': Number(this.epsGatewayId),
@@ -424,7 +514,7 @@
                             body: JSON.stringify(
                                 {
                                     'order_id': orderId,
-                                    'public_order_id': '<?php echo $this->getPublicOrderID(); ?>',
+                                    'public_order_id': this.publicOrderId,
                                     'gateway_type': 'ppcp',
                                 }
                             ),
@@ -581,9 +671,7 @@
 
     });
     document.observe('dom:loaded', function () {
-        if (typeof window.bold === 'undefined') {
-            window.bold = {};
-        }
+        window.bold.publicOrderId = '<?php echo $this->getPublicOrderID(); ?>';
         window.bold.baseInstance = new BoldBase();
     });
 </script>

--- a/design/frontend/base/default/template/bold/checkout_payment_booster/payment/form/bold_method.phtml
+++ b/design/frontend/base/default/template/bold/checkout_payment_booster/payment/form/bold_method.phtml
@@ -168,13 +168,55 @@
         showPaymentMethod: function () {
             this.paymentMethodElement.style.display = 'block';
         },
+        getSpiPostMessageTargetOrigin: function () {
+            if (window.bold.baseInstance && window.bold.baseInstance.epsUrl) {
+                try {
+                    return new URL(window.bold.baseInstance.epsUrl).origin;
+                } catch (e) {
+                    return '*';
+                }
+            }
+
+            return '*';
+        },
+        isTrustedSpiMessage: function (event) {
+            if (!event || !event.data || !event.data.eventType) {
+                return false;
+            }
+
+            const iframe = document.getElementById('spi_frame_payment_form_bold');
+            if (iframe && iframe.contentWindow && event.source === iframe.contentWindow) {
+                return true;
+            }
+
+            if (window.bold.baseInstance && window.bold.baseInstance.epsUrl) {
+                try {
+                    const epsOrigin = new URL(window.bold.baseInstance.epsUrl).origin;
+                    if (event.origin === epsOrigin) {
+                        return true;
+                    }
+                } catch (e) {
+                    return false;
+                }
+            }
+
+            return false;
+        },
         /**
          * Send tokenize action to SPI iframe.
          *
          * @return {Promise<void>}
          */
         tokenize: async function () {
-            const iframeWindow = document.getElementById('spi_frame_payment_form_bold').contentWindow;
+            const iframe = document.getElementById('spi_frame_payment_form_bold');
+            if (!iframe || !iframe.contentWindow) {
+                console.error('SPI iframe not found');
+                if (typeof checkout !== 'undefined' && checkout.setLoadWaiting) {
+                    checkout.setLoadWaiting(false);
+                }
+                return;
+            }
+
             const cartData = await window.bold.baseInstance.getCartData();
             const payload = {
                 customer: cartData.customer,
@@ -182,47 +224,59 @@
                 shipping_address: cartData.shipping_address || cartData.billing_address,
                 totals: cartData.totals,
             };
-            iframeWindow.postMessage({actionType: 'ACTION_SPI_TOKENIZE', payload: payload}, '*');
+            const targetOrigin = this.getSpiPostMessageTargetOrigin();
+            iframe.contentWindow.postMessage(
+                {actionType: 'ACTION_SPI_TOKENIZE', payload: payload},
+                targetOrigin
+            );
         },
         /**
          * Subscribe to SPI iframe events.
          *
          * @returns {void}
          */
-        subscribeToSpiEvents() {
-            window.addEventListener('message', ({data}) => {
+        subscribeToSpiEvents: function () {
+            const self = this;
+            window.addEventListener('message', function (event) {
+                if (!self.isTrustedSpiMessage(event)) {
+                    return;
+                }
+
+                const data = event.data;
                 const eventType = data.eventType;
-                if (eventType) {
-                    switch (eventType) {
-                        case 'EVENT_SPI_TOKENIZED':
-                            if (!data.payload.success) {
-                                this.paymentId = null;
-                                console.error('Failed to tokenize');
-                                checkout.setLoadWaiting(false);
-                                return;
-                            }
-                            this.paymentId = data.payload?.payload?.data?.payment_id;
-                            if (checkout.save) {
-                                checkout.save();
-                                return;
-                            }
-                            payment.save();
-                            break;
-                        case 'EVENT_SPI_TOKENIZE_FAILED':
-                            this.paymentId = null;
+                if (!eventType) {
+                    return;
+                }
+
+                switch (eventType) {
+                    case 'EVENT_SPI_TOKENIZED':
+                        if (!data.payload.success) {
+                            self.paymentId = null;
                             console.error('Failed to tokenize');
                             checkout.setLoadWaiting(false);
-                            break;
-                        case 'EVENT_SPI_PAYMENT_ORDER_SCA':
-                            checkout.setLoadWaiting(false);
-                            break;
-                        case 'EVENT_SPI_ENABLE_FULLSCREEN':
-                            checkout.setLoadWaiting(false);
-                            break;
-                        case 'EVENT_SPI_DISABLE_FULLSCREEN':
-                            checkout.setLoadWaiting('payment', true);
-                            break;
-                    }
+                            return;
+                        }
+                        self.paymentId = data.payload?.payload?.data?.payment_id;
+                        if (checkout.save) {
+                            checkout.save();
+                            return;
+                        }
+                        payment.save();
+                        break;
+                    case 'EVENT_SPI_TOKENIZE_FAILED':
+                        self.paymentId = null;
+                        console.error('Failed to tokenize');
+                        checkout.setLoadWaiting(false);
+                        break;
+                    case 'EVENT_SPI_PAYMENT_ORDER_SCA':
+                        checkout.setLoadWaiting(false);
+                        break;
+                    case 'EVENT_SPI_ENABLE_FULLSCREEN':
+                        checkout.setLoadWaiting(false);
+                        break;
+                    case 'EVENT_SPI_DISABLE_FULLSCREEN':
+                        checkout.setLoadWaiting('payment', true);
+                        break;
                 }
             });
         },

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Bold_CheckoutPaymentBooster>
-            <version>2.1.5</version>
+            <version>2.1.6</version>
         </Bold_CheckoutPaymentBooster>
     </modules>
     <global>
@@ -92,6 +92,22 @@
                     </authorize_bold_payment>
                 </observers>
             </checkout_type_onepage_save_order>
+            <controller_action_predispatch_checkout_onepage_saveOrder>
+                <observers>
+                    <bold_checkout_prevent_duplicate_save_order>
+                        <class>Bold_CheckoutPaymentBooster_Observer_SaveOrderObserver</class>
+                        <method>predispatchSaveOrder</method>
+                    </bold_checkout_prevent_duplicate_save_order>
+                </observers>
+            </controller_action_predispatch_checkout_onepage_saveOrder>
+            <controller_action_postdispatch_checkout_onepage_saveOrder>
+                <observers>
+                    <bold_checkout_clear_placement_state>
+                        <class>Bold_CheckoutPaymentBooster_Observer_SaveOrderObserver</class>
+                        <method>cleanupAfterSaveOrder</method>
+                    </bold_checkout_clear_placement_state>
+                </observers>
+            </controller_action_postdispatch_checkout_onepage_saveOrder>
         </events>
         <routers>
             <checkoutpaymentbooster>
@@ -114,22 +130,10 @@
         <events>
             <admin_system_config_changed_section_checkout>
                 <observers>
-                    <save_shop_info>
+                    <bold_checkout_config_save_pipeline>
                         <class>Bold_CheckoutPaymentBooster_Observer_ConfigObserver</class>
-                        <method>saveShopInfo</method>
-                    </save_shop_info>
-                    <add_domain_to_cors_allow_list>
-                        <class>Bold_CheckoutPaymentBooster_Observer_ConfigObserver</class>
-                        <method>addDomainToCorsAllowList</method>
-                    </add_domain_to_cors_allow_list>
-                    <set_rsa_config>
-                        <class>Bold_CheckoutPaymentBooster_Observer_ConfigObserver</class>
-                        <method>setRsaConfig</method>
-                    </set_rsa_config>
-                    <process_flows>
-                        <class>Bold_CheckoutPaymentBooster_Observer_ConfigObserver</class>
-                        <method>processFlows</method>
-                    </process_flows>
+                        <method>onCheckoutConfigChanged</method>
+                    </bold_checkout_config_save_pipeline>
                 </observers>
             </admin_system_config_changed_section_checkout>
         </events>
@@ -171,6 +175,7 @@
                 <weight_conversion_rate>1000</weight_conversion_rate>
                 <fastlane_email_container_styles>width: 365px</fastlane_email_container_styles>
                 <is_log_enabled>0</is_log_enabled>
+                <is_check_shared_enabled>0</is_check_shared_enabled>
             </bold_checkout_payment_booster_advanced>
         </checkout>
         <payment>

--- a/etc/system.xml
+++ b/etc/system.xml
@@ -106,7 +106,7 @@
                         <api_token>
                             <label>API Token</label>
                             <frontend_type>obscure</frontend_type>
-                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
+                            <backend_model>bold_checkout_payment_booster/adminhtml_system_config_backend_apiToken</backend_model>
                             <sort_order>20</sort_order>
                             <show_in_default>0</show_in_default>
                             <show_in_website>1</show_in_website>
@@ -116,6 +116,18 @@
                                 <is_payment_booster_enabled>1</is_payment_booster_enabled>
                             </depends>
                         </api_token>
+                        <rotate_shared_key translate="label">
+                            <label>Rotate Shared Key</label>
+                            <frontend_type>button</frontend_type>
+                            <frontend_model>bold_checkout_payment_booster/adminhtml_system_config_button_rotateSharedKey</frontend_model>
+                            <sort_order>25</sort_order>
+                            <show_in_default>0</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <depends>
+                                <is_payment_booster_enabled>1</is_payment_booster_enabled>
+                            </depends>
+                            <comment><![CDATA[ Rotates the shared secret used by Bold to sign inbound payment webhooks. Use this if webhooks are failing authentication. ]]></comment>
+                        </rotate_shared_key>
                     </fields>
                 </bold_checkout_payment_booster>
                 <bold_checkout_payment_booster_advanced translate="label">

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,71 @@
+# Release 2.1.6 patches
+
+Apply on top of **Bold CheckoutPaymentBooster 2.1.5** (`5270dd3` / `etc/config.xml` version `2.1.5`).
+
+## Patches
+
+| File | Use on server |
+|------|----------------|
+| `release-2.1.6-production.patch` | **Recommended** — module runtime files only (no tests) |
+| `release-2.1.6.patch` | Full release including tests and security scripts (excludes `tests/unit/composer.lock`) |
+
+## Prerequisites
+
+- Module installed at `app/code/community/Bold/CheckoutPaymentBooster/` (or equivalent via modman/symlink).
+- Current version **2.1.5** with unmodified 2.1.6 files (patch will fail if already partially applied).
+- Backup the module directory before applying.
+
+## Apply (from Magento root)
+
+```bash
+cd /path/to/magento
+
+# Dry run
+patch -p0 --dry-run < app/code/community/Bold/CheckoutPaymentBooster/patches/release-2.1.6-production.patch
+
+# Apply
+patch -p0 < app/code/community/Bold/CheckoutPaymentBooster/patches/release-2.1.6-production.patch
+```
+
+If paths in the patch use `a/` and `b/` prefixes (git diff), use **git apply** from the module root instead:
+
+```bash
+cd app/code/community/Bold/CheckoutPaymentBooster
+git apply --check patches/release-2.1.6-production.patch
+git apply patches/release-2.1.6-production.patch
+```
+
+## After apply
+
+1. Confirm `etc/config.xml` shows `<version>2.1.6</version>`.
+2. Run Magento upgrade so the DB script runs:
+   ```bash
+   php shell/index.php   # or your deploy hook
+   # Admin: System > Configuration > Advanced > Developer > flush caches
+   ```
+   The upgrade adds unique index `UNQ_BOLD_CHECKOUT_PAYMENT_BOOSTER_ORDER_PUBLIC_ID` on `bold_checkout_payment_booster_order.public_id`.
+
+3. Clear Magento cache.
+
+## Verify
+
+- Standard checkout `checkout/onepage/saveOrder` with Bold payment.
+- RSA: save config once; inbound webhooks succeed; Re-sync RSA button available in admin.
+- Logs (if issues): `var/log/bold_checkout_payment_booster.log` (`[PlacementGuard]` / `[DuplicateOrder]` prefixes when Enable Log is on).
+
+## Rollback
+
+Restore backup of `app/code/community/Bold/CheckoutPaymentBooster/` from before the patch. Revert `etc/config.xml` version to `2.1.5` only if you did not run the upgrade script; if upgrade ran, the DB index remains (harmless).
+
+## Contents (production patch)
+
+- **RSA hardening** — SavePipeline, Connect POST-first, Re-sync button, inbound HMAC fallback, API token fingerprint
+- **PlacementGuard + CheckoutSessionOwnership** — duplicate order / session ownership / Express Pay IDOR
+- **SaveOrderObserver** on `checkout/onepage/saveOrder`
+- **CheckoutObserver**, **ExpresspayController**, payment models
+- **422 fix** — `Service/Bold` public_order_id rotation, `IndexController`, wallet `base.phtml`
+- **Wallet EPS coalesce** — parallel `createOrder` deduplication
+- SPI postMessage hardening (`bold_method.phtml`)
+- `mysql4-upgrade-2.1.5-2.1.6.php`
+
+**Not included:** Firecheckout-specific changes (deferred to 2.2.x).

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/unit/bootstrap.php"
+         colors="true"
+         convertDeprecationsToExceptions="false">
+    <testsuites>
+        <testsuite name="Bold Checkout Payment Booster Unit Tests">
+            <directory>tests/unit</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">Service</directory>
+            <directory suffix=".php">Model</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/security-fix.md
+++ b/security-fix.md
@@ -1,0 +1,77 @@
+# Security fixes — `fix/rsa-auth-hardening` (2.1.6 unified)
+
+**Branch:** `fix/rsa-auth-hardening`  
+**Reference patch:** `patches/release-2.1.6-production.patch`  
+**Verification:** `tests/SECURITY.md` + PHPUnit in `tests/unit/`
+
+---
+
+## Current state on `fix/rsa-auth-hardening`
+
+| Fix | Status |
+|-----|--------|
+| Duplicate `saveOrder` guards (`PlacementGuard`, `SaveOrderObserver`) | **Applied** — wired on `checkout/onepage/saveOrder` |
+| `success_existing` session ownership | **Applied** — `buildSuccessExistingEvaluation()` in full `PlacementGuard` |
+| Express Pay quote IDOR binding | **Applied** — `loadCheckoutSessionQuoteForRequest()` in `ExpresspayController` |
+| Submit-time guards (`assertQuoteCanSubmit` + ownership) | **Applied** — `CheckoutObserver::beforeSaveOrder` |
+| 422 auth/full (`public_order_id` rotation) | **Applied** — `Service/Bold::initBoldCheckoutData` + `IndexController::getCheckoutSessionAction` |
+| Wallet EPS 15s coalesce | **Applied** — `getRecentWalletEpsOrderId` in `ExpresspayController::createOrderAction` |
+| RSA hardening (SavePipeline, Re-sync, HMAC) | **Applied** |
+| DB unique index on `public_id` | **Applied** — `mysql4-upgrade-2.1.5-2.1.6.php` |
+| PHPUnit + curl scripts | **Applied** — 33 tests pass |
+
+**Out of scope:** Firecheckout-specific routes/observers (deferred to 2.2.x per `patches/README.md`).
+
+---
+
+## Verify
+
+### Unit tests
+
+```bash
+cd app/code/community/Bold/CheckoutPaymentBooster/tests/unit
+composer install
+./vendor/bin/phpunit -c phpunit.xml.dist
+```
+
+### Manual / curl (staging)
+
+See [tests/SECURITY.md](tests/SECURITY.md):
+
+- **A** — EPS session hijack (completed order)
+- **A2** — EPS session hijack (in-flight)
+- **B** — Express Pay quote IDOR
+- **C** — Standard checkout regression smoke
+- **D** — IndexController POST/Ajax/form-key
+
+Curl scripts in `tests/curl/`:
+
+- `saveorder-eps-hijack.sh`
+- `saveorder-eps-hijack-inflight.sh`
+- `expresspay-quote-idor.sh`
+
+### RSA (production)
+
+1. Save Bold config once at website scope
+2. Confirm inbound webhooks return 200 (no `Authorization failed` / `matched=NO`)
+3. Use **Re-sync RSA with Bold** if shared secret drift recurs
+
+---
+
+## Known open items (follow-up)
+
+| Item | Severity | Notes |
+|------|----------|-------|
+| `expresspay/getOrder` not session-bound | Medium | EPS ids hard to guess; bind in follow-up |
+| Firecheckout duplicate guard wiring | Medium | Standard checkout only in 2.1.6 |
+| Admin log export ACL | Low | `LogsController::_isAllowed()` |
+
+---
+
+## Rollback
+
+If guards block legitimate checkout:
+
+1. Check `bold_checkout_payment_booster.log` for `success_existing_rejected_*` or `[PlacementGuard]`.
+2. Verify guest email is on quote before place order (ownership uses email match for guests).
+3. Temporarily disable `SaveOrderObserver` wiring in `config.xml` only after confirming false positive — do not remove ownership fix in production without replacement.

--- a/skin/frontend/base/default/js/bold/checkout_payment_booster/expresspay.js
+++ b/skin/frontend/base/default/js/bold/checkout_payment_booster/expresspay.js
@@ -822,6 +822,9 @@ const ExpressPay = async config => (async config => {
                 config.getCartTotalsUrl,
                 {
                     method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest'
+                    },
                     body: formData
                 }
             );
@@ -853,6 +856,9 @@ const ExpressPay = async config => (async config => {
                 config.getCartItemsUrl,
                 {
                     method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest'
+                    },
                     body: formData
                 }
             );

--- a/sql/bold_checkout_payment_booster_setup/mysql4-upgrade-2.1.5-2.1.6.php
+++ b/sql/bold_checkout_payment_booster_setup/mysql4-upgrade-2.1.5-2.1.6.php
@@ -1,0 +1,19 @@
+<?php
+
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$orderTableName = $installer->getTable(Bold_CheckoutPaymentBooster_Model_Order::RESOURCE);
+$connection = $installer->getConnection();
+
+$indexName = 'UNQ_BOLD_CHECKOUT_PAYMENT_BOOSTER_ORDER_PUBLIC_ID';
+$indexes = $connection->getIndexList($orderTableName);
+
+if (!isset($indexes[strtoupper($indexName)])) {
+    $installer->run(
+        "ALTER TABLE `{$orderTableName}` ADD UNIQUE INDEX `{$indexName}` (`public_id`)"
+    );
+}
+
+$installer->endSetup();

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,21 @@
+# Bold CheckoutPaymentBooster tests
+
+## Unit tests (no full Magento install)
+
+From this directory:
+
+```bash
+cd app/code/community/Bold/CheckoutPaymentBooster/tests/unit
+composer require --dev phpunit/phpunit:^9
+./vendor/bin/phpunit -c phpunit.xml.dist
+```
+
+Or with a global PHPUnit 9+:
+
+```bash
+phpunit -c app/code/community/Bold/CheckoutPaymentBooster/tests/unit/phpunit.xml.dist
+```
+
+## Security verification on staging
+
+See [SECURITY.md](SECURITY.md) and the curl helpers in [curl/](curl/).

--- a/tests/SECURITY.md
+++ b/tests/SECURITY.md
@@ -1,0 +1,110 @@
+# Security verification — CheckoutPaymentBooster
+
+Manual checks for **2.1.6** (standard `checkout/onepage` + Express Pay security). Run on **staging** before production.
+
+**2.1.6 scope:** Duplicate-order predispatch runs on `checkout/onepage/saveOrder` only (not Firecheckout). Firecheckout + wallet UX is planned for 2.2.x.
+
+Wallet EPS session binding (`assertWalletEpsOrderIdBelongsToSession`) runs on Express Pay Ajax **and** on Bold `saveOrder` predispatch / `assertQuoteCanSubmit` when `payment[additional_data][order_id]` is present.
+
+## Prerequisites
+
+- Bold Payment Booster enabled; **standard one-page checkout** with Bold and/or Express Pay / wallet buttons.
+- Two isolated browser profiles (Session A / Session B).
+- Access to `var/log/bold_checkout_payment_booster.log` (Enable Log must be Yes in Bold advanced settings).
+- Optional: curl scripts in [curl/](curl/) (set env vars documented in each script).
+
+---
+
+## A. EPS session hijack — completed order (PlacementGuard ownership)
+
+**Goal:** Another shopper cannot get a success redirect by reusing someone else's EPS `order_id` after Session A already placed an order.
+
+1. **Session A:** Complete checkout with Bold wallet (Apple Pay / Google Pay) or note EPS id from Network tab: `payment[additional_data][order_id]` on `saveOrder`.
+2. **Session B:** New guest or different customer; add product; reach checkout payment step.
+3. Capture B's cookies and `form_key` from checkout page source or DevTools.
+4. **Session B:** POST `saveOrder` to `/checkout/onepage/saveOrder` with:
+   - B's `form_key`
+   - `payment[method]=bold`
+   - `payment[additional_data][order_id]=<A's EPS order id>`
+   - Other required fields from a normal place-order request (copy from DevTools).
+
+**Automated:** [curl/saveorder-eps-hijack.sh](curl/saveorder-eps-hijack.sh)
+
+**Expected:**
+
+- Response is an **error** (not `{"success":true,"redirect":...}` to A's order).
+- B's checkout session must **not** show A's increment id on success page.
+- Log contains `success_existing_rejected_eps_order_id` or `assert_rejected_assert_eps_order_id`.
+
+5. **Session A:** Repeat `saveOrder` with the same EPS id (legitimate duplicate submit).
+
+**Expected:**
+
+- `success_existing` JSON with redirect to success.
+- Still only **one** Magento order for that payment.
+
+---
+
+## A2. EPS session hijack — in-flight (before Session A saveOrder)
+
+**Goal:** Session B cannot place an order using Session A's EPS `order_id` when A created the wallet order via Express Pay but has **not** yet called `saveOrder`.
+
+1. **Session A:** Open standard checkout; start Apple Pay / Google Pay; complete wallet sheet so `expresspay/createOrder` returns an EPS `order_id`. **Do not** place the Magento order.
+2. Copy A's EPS `order_id` from the Network tab (or from `expresspay/createOrder` response).
+3. **Session B:** Separate browser profile; add product; reach checkout payment step.
+4. **Session B:** POST `saveOrder` with B's `form_key` and A's EPS `order_id` (same as section A step 4).
+
+**Automated:** [curl/saveorder-eps-hijack-inflight.sh](curl/saveorder-eps-hijack-inflight.sh) — same env as `saveorder-eps-hijack.sh`, but use an EPS id captured **before** Session A completes `saveOrder`.
+
+**Expected:**
+
+- Response is an **error** (authorization failure or "not authorized to access this payment").
+- No Magento order created for Session B.
+- Session A can still complete `saveOrder` normally with its own EPS id.
+
+---
+
+## B. Express Pay quote IDOR
+
+**Goal:** Cannot create/update Bold `wallet_pay` for another customer's quote.
+
+1. **Session A:** Open checkout; note `quote_id` in Express Pay Ajax or DB `sales_flat_quote.entity_id`.
+2. Obtain **foreign** active quote id (Session B checkout, or admin).
+3. Run [curl/expresspay-quote-idor.sh](curl/expresspay-quote-idor.sh) with `FOREIGN_QUOTE_ID` set.
+
+**Expected:**
+
+- HTTP **403** and JSON `error` when using foreign `quote_id`.
+- HTTP **200** with `order_id` when using own `quote_id` or empty string (session default).
+
+---
+
+## C. Regression smoke (standard checkout)
+
+- Bold SPI card checkout places order.
+- Express Pay / wallet create order + place order on **checkout/onepage** (if enabled).
+- Other payment methods still selectable and place order.
+- Non-Bold `saveOrder` unaffected (guards only when `payment[method]` is `bold` or `bold_fastlane`).
+- Duplicate `saveOrder` on same session logs `[PlacementGuard]` / `[DuplicateOrder]` lines in `bold_checkout_payment_booster.log` and returns `success_existing` when appropriate.
+
+---
+
+## D. IndexController cart endpoints
+
+**Goal:** Cart data Ajax requires POST + `X-Requested-With: XMLHttpRequest` + valid form key.
+
+1. GET `/checkoutpaymentbooster/index/getCartData?form_key=...` → **404** (noroute).
+2. POST without Ajax header → **404**.
+3. POST with Ajax header and invalid form key → **403** JSON `error`.
+
+---
+
+## Unit tests (local)
+
+```bash
+cd app/code/community/Bold/CheckoutPaymentBooster/tests/unit
+composer install
+./vendor/bin/phpunit -c phpunit.xml.dist
+```
+
+See [README.md](README.md).

--- a/tests/curl/expresspay-quote-idor.sh
+++ b/tests/curl/expresspay-quote-idor.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Verifies expresspay/createOrder rejects a foreign quote_id (403).
+#
+# Required env:
+#   BASE_URL          e.g. https://staging.example.com
+#   COOKIE_JAR        path to Netscape cookie jar from checkout session
+#   FORM_KEY          from checkout page
+#   QUOTE_ID          session quote id (must match cookie session)
+#   FOREIGN_QUOTE_ID  another active quote id
+#   GATEWAY_ID        EPS gateway id from Bold checkout config
+#
+set -euo pipefail
+
+: "${BASE_URL:?}"
+: "${COOKIE_JAR:?}"
+: "${FORM_KEY:?}"
+: "${QUOTE_ID:?}"
+: "${FOREIGN_QUOTE_ID:?}"
+: "${GATEWAY_ID:?}"
+
+ENDPOINT="${BASE_URL%/}/checkoutpaymentbooster/expresspay/createOrder"
+
+post_create() {
+  local quote_id="$1"
+  curl -sS -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+    -X POST "$ENDPOINT" \
+    -H 'X-Requested-With: XMLHttpRequest' \
+    -H 'Content-Type: application/json' \
+    -d "{\"form_key\":\"${FORM_KEY}\",\"quote_id\":\"${quote_id}\",\"gateway_id\":\"${GATEWAY_ID}\",\"shipping_strategy\":\"dynamic\"}" \
+    -w '\nHTTP_CODE:%{http_code}\n'
+}
+
+echo "=== Foreign quote_id (expect HTTP 403) ==="
+RESP_FOREIGN="$(post_create "$FOREIGN_QUOTE_ID")"
+echo "$RESP_FOREIGN"
+if ! echo "$RESP_FOREIGN" | grep -q 'HTTP_CODE:403'; then
+  echo "FAIL: expected HTTP 403 for foreign quote_id" >&2
+  exit 1
+fi
+if ! echo "$RESP_FOREIGN" | grep -q '"error"'; then
+  echo "FAIL: expected JSON error body" >&2
+  exit 1
+fi
+
+echo "=== Own quote_id (expect HTTP 200 and order_id) ==="
+RESP_OWN="$(post_create "$QUOTE_ID")"
+echo "$RESP_OWN"
+if ! echo "$RESP_OWN" | grep -q 'HTTP_CODE:200'; then
+  echo "FAIL: expected HTTP 200 for own quote_id" >&2
+  exit 1
+fi
+if ! echo "$RESP_OWN" | grep -q '"order_id"'; then
+  echo "FAIL: expected order_id in response" >&2
+  exit 1
+fi
+
+echo "PASS: quote IDOR checks completed"

--- a/tests/curl/saveorder-eps-hijack-inflight.sh
+++ b/tests/curl/saveorder-eps-hijack-inflight.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Verifies saveOrder with another shopper's in-flight EPS order_id (Session A created
+# expresspay/createOrder but has NOT yet saveOrder'd) does not succeed for Session B.
+#
+# Required env:
+#   BASE_URL       e.g. https://staging.example.com
+#   COOKIE_JAR_B   cookie jar for Session B (attacker / second shopper)
+#   FORM_KEY_B     form_key from B's checkout page
+#   EPS_ORDER_ID   EPS order id from Session A's expresspay/createOrder (A has NOT saveOrder'd yet)
+#   SAVE_ORDER_URL e.g. /firecheckout/index/saveOrder or /checkout/onepage/saveOrder
+#
+# Optional:
+#   SAVE_ORDER_BODY  full urlencoded body from a valid B saveOrder minus payment fields;
+#                    script appends payment[method]=bold and payment[additional_data][order_id]
+#
+set -euo pipefail
+
+: "${BASE_URL:?}"
+: "${COOKIE_JAR_B:?}"
+: "${FORM_KEY_B:?}"
+: "${EPS_ORDER_ID:?}"
+: "${SAVE_ORDER_URL:?}"
+
+URL="${BASE_URL%/}/${SAVE_ORDER_URL#/}"
+
+ENCODED_EPS="$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$EPS_ORDER_ID")"
+if [[ -n "${SAVE_ORDER_BODY:-}" ]]; then
+  BODY="${SAVE_ORDER_BODY}&payment[method]=bold&payment[additional_data][order_id]=${ENCODED_EPS}"
+else
+  BODY="form_key=${FORM_KEY_B}&payment[method]=bold&payment[additional_data][order_id]=${ENCODED_EPS}"
+fi
+
+echo "POST $URL (in-flight EPS hijack test)"
+RESP="$(curl -sS -b "$COOKIE_JAR_B" -c "$COOKIE_JAR_B" \
+  -X POST "$URL" \
+  -H 'X-Requested-With: XMLHttpRequest' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-raw "$BODY" \
+  -w '\nHTTP_CODE:%{http_code}\n')"
+
+echo "$RESP"
+
+if echo "$RESP" | grep -q '"success":true'; then
+  echo "FAIL: saveOrder returned success — possible in-flight EPS hijack" >&2
+  exit 1
+fi
+
+if echo "$RESP" | grep -q 'HTTP_CODE:200' && echo "$RESP" | grep -q '"redirect"'; then
+  echo "FAIL: got success redirect with foreign in-flight EPS order_id" >&2
+  exit 1
+fi
+
+echo "PASS: foreign in-flight EPS order_id did not yield success redirect"

--- a/tests/curl/saveorder-eps-hijack.sh
+++ b/tests/curl/saveorder-eps-hijack.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Verifies saveOrder with another shopper's EPS order_id does not return success_existing hijack.
+#
+# Required env:
+#   BASE_URL       e.g. https://staging.example.com
+#   COOKIE_JAR_B   cookie jar for Session B (attacker / second shopper)
+#   FORM_KEY_B     form_key from B's checkout page
+#   EPS_ORDER_ID   EPS order id from Session A's completed wallet payment
+#   SAVE_ORDER_URL e.g. /firecheckout/index/saveOrder or /checkout/onepage/saveOrder
+#
+# Optional:
+#   SAVE_ORDER_BODY  full urlencoded body from a valid B saveOrder minus payment fields;
+#                    script appends payment[method]=bold and payment[additional_data][order_id]
+#
+set -euo pipefail
+
+: "${BASE_URL:?}"
+: "${COOKIE_JAR_B:?}"
+: "${FORM_KEY_B:?}"
+: "${EPS_ORDER_ID:?}"
+: "${SAVE_ORDER_URL:?}"
+
+URL="${BASE_URL%/}/${SAVE_ORDER_URL#/}"
+
+ENCODED_EPS="$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$EPS_ORDER_ID")"
+if [[ -n "${SAVE_ORDER_BODY:-}" ]]; then
+  BODY="${SAVE_ORDER_BODY}&payment[method]=bold&payment[additional_data][order_id]=${ENCODED_EPS}"
+else
+  BODY="form_key=${FORM_KEY_B}&payment[method]=bold&payment[additional_data][order_id]=${ENCODED_EPS}"
+fi
+
+echo "POST $URL"
+RESP="$(curl -sS -b "$COOKIE_JAR_B" -c "$COOKIE_JAR_B" \
+  -X POST "$URL" \
+  -H 'X-Requested-With: XMLHttpRequest' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-raw "$BODY" \
+  -w '\nHTTP_CODE:%{http_code}\n')"
+
+echo "$RESP"
+
+if echo "$RESP" | grep -q '"success":true'; then
+  echo "FAIL: saveOrder returned success — possible session hijack" >&2
+  exit 1
+fi
+
+if echo "$RESP" | grep -q 'HTTP_CODE:200' && echo "$RESP" | grep -q '"redirect"'; then
+  echo "FAIL: got success redirect with foreign EPS order_id" >&2
+  exit 1
+fi
+
+echo "PASS: foreign EPS order_id did not yield success redirect"

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+.phpunit.result.cache

--- a/tests/unit/CheckoutSessionOwnershipTest.php
+++ b/tests/unit/CheckoutSessionOwnershipTest.php
@@ -1,0 +1,243 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class CheckoutSessionOwnershipTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::reset();
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            new Bold_CheckoutPaymentBooster_Model_Config()
+        );
+    }
+
+    public function testOrderBelongsWhenQuoteIdsMatchForGuestWithoutEmails()
+    {
+        $order = new Mage_Sales_Model_Order(array(
+            'entity_id' => 10,
+            'quote_id' => 5,
+            'customer_id' => 0,
+        ));
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'customer_id' => 0,
+        ));
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::orderBelongsToCheckoutSession(
+                $order,
+                $quote
+            )
+        );
+    }
+
+    public function testOrderDoesNotBelongWhenQuoteIdsDiffer()
+    {
+        $order = new Mage_Sales_Model_Order(array(
+            'entity_id' => 10,
+            'quote_id' => 5,
+            'customer_id' => 0,
+        ));
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 99,
+            'customer_id' => 0,
+        ));
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::orderBelongsToCheckoutSession(
+                $order,
+                $quote
+            )
+        );
+    }
+
+    public function testLoggedInCustomerMustMatch()
+    {
+        $order = new Mage_Sales_Model_Order(array(
+            'entity_id' => 10,
+            'quote_id' => 5,
+            'customer_id' => 1,
+        ));
+        $matchingQuote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'customer_id' => 1,
+        ));
+        $foreignQuote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'customer_id' => 2,
+        ));
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::orderBelongsToCheckoutSession(
+                $order,
+                $matchingQuote
+            )
+        );
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::orderBelongsToCheckoutSession(
+                $order,
+                $foreignQuote
+            )
+        );
+    }
+
+    public function testGuestEmailMustMatchWhenBothPresent()
+    {
+        $order = new Mage_Sales_Model_Order(array(
+            'entity_id' => 10,
+            'quote_id' => 5,
+            'customer_id' => 0,
+            'customer_email_direct' => 'alice@example.com',
+        ));
+        $matchingQuote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'customer_id' => 0,
+            'customer_email' => 'Alice@Example.com',
+        ));
+        $foreignQuote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'customer_id' => 0,
+            'customer_email' => 'bob@example.com',
+        ));
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::orderBelongsToCheckoutSession(
+                $order,
+                $matchingQuote
+            )
+        );
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::orderBelongsToCheckoutSession(
+                $order,
+                $foreignQuote
+            )
+        );
+    }
+
+    public function testBuildSuccessExistingReturnsBlockForForeignOrder()
+    {
+        $order = new Mage_Sales_Model_Order(array(
+            'entity_id' => 10,
+            'quote_id' => 5,
+            'increment_id' => '100000010',
+            'customer_id' => 0,
+            'customer_email_direct' => 'alice@example.com',
+        ));
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 99,
+            'customer_id' => 0,
+            'customer_email' => 'bob@example.com',
+        ));
+
+        $result = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::buildSuccessExistingEvaluation(
+            $order,
+            $quote,
+            'eps_order_id'
+        );
+
+        $this->assertSame('block', $result['action']);
+        $this->assertArrayHasKey('message', $result);
+        $this->assertNotEmpty(Bold_CheckoutPaymentBooster_Test_Stub_Mage::$logMessages);
+    }
+
+    public function testBuildSuccessExistingReturnsSuccessForOwnedOrder()
+    {
+        $order = new Mage_Sales_Model_Order(array(
+            'entity_id' => 10,
+            'quote_id' => 5,
+            'increment_id' => '100000011',
+            'customer_id' => 1,
+        ));
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'customer_id' => 1,
+        ));
+
+        $result = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::buildSuccessExistingEvaluation(
+            $order,
+            $quote,
+            'inactive_quote'
+        );
+
+        $this->assertSame('success_existing', $result['action']);
+        $this->assertSame($order, $result['order']);
+    }
+
+    public function testAssertQuoteMatchesCheckoutSessionThrows403WhenMismatch()
+    {
+        $session = new Mage_Checkout_Model_Session(array('quote_id' => 5));
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton('checkout/session', $session);
+
+        $quote = new Mage_Sales_Model_Quote(array('entity_id' => 99));
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionCode(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::EXCEPTION_QUOTE_ACCESS_DENIED
+        );
+
+        Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::assertQuoteMatchesCheckoutSession($quote);
+    }
+
+    public function testLoadCheckoutSessionQuoteRejectsForeignQuoteId()
+    {
+        $session = new Mage_Checkout_Model_Session(array('quote_id' => 5));
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton('checkout/session', $session);
+
+        $foreignQuote = new Mage_Sales_Model_Quote(array('entity_id' => 99));
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setQuoteById('99', $foreignQuote);
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionCode(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::EXCEPTION_QUOTE_ACCESS_DENIED
+        );
+
+        Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::loadCheckoutSessionQuote('99');
+    }
+
+    public function testLoadCheckoutSessionQuoteReturnsSessionQuoteWhenParamEmpty()
+    {
+        $quote = new Mage_Sales_Model_Quote(array('entity_id' => 5));
+        $session = new Mage_Checkout_Model_Session(array(
+            'quote_id' => 5,
+            'quote' => $quote,
+        ));
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton('checkout/session', $session);
+
+        $loaded = Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::loadCheckoutSessionQuote('');
+
+        $this->assertSame($quote, $loaded);
+    }
+
+    public function testRegisterAndAssertWalletEpsOrderId()
+    {
+        $session = new Mage_Checkout_Model_Session();
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton('checkout/session', $session);
+
+        Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::registerWalletEpsOrderId('eps-abc-123');
+
+        Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::assertWalletEpsOrderIdBelongsToSession(
+            'eps-abc-123'
+        );
+
+        $this->assertTrue(true);
+    }
+
+    public function testAssertWalletEpsOrderIdRejectsForeignId()
+    {
+        $session = new Mage_Checkout_Model_Session(array(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::SESSION_WALLET_EPS_ORDER_ID => 'eps-mine',
+        ));
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton('checkout/session', $session);
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionCode(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::EXCEPTION_QUOTE_ACCESS_DENIED
+        );
+
+        Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::assertWalletEpsOrderIdBelongsToSession(
+            'eps-theirs'
+        );
+    }
+}

--- a/tests/unit/PlacementGuardTest.php
+++ b/tests/unit/PlacementGuardTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class PlacementGuardTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::reset();
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            new Bold_CheckoutPaymentBooster_Model_Config()
+        );
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::releaseLock();
+    }
+
+    public function testEvaluateReturnsBlockWhenQuoteMissing()
+    {
+        $session = new Mage_Checkout_Model_Session();
+
+        $result = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::evaluatePlacementRequestForQuote(
+            $session,
+            null
+        );
+
+        $this->assertSame('block', $result['action']);
+    }
+
+    public function testEvaluateReturnsBlockInProgressWhenPlacementFlagSet()
+    {
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'is_active' => 1,
+        ));
+        $session = new Mage_Checkout_Model_Session(array(
+            'quote' => $quote,
+            Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::SESSION_PLACEMENT_FLAG => 1,
+        ));
+
+        $result = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::evaluatePlacementRequestForQuote(
+            $session,
+            $quote
+        );
+
+        $this->assertSame('block_in_progress', $result['action']);
+    }
+
+    public function testEvaluateReturnsAllowForActiveQuoteWithoutDuplicates()
+    {
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'is_active' => 1,
+        ));
+        $session = new Mage_Checkout_Model_Session(array('quote' => $quote));
+
+        $result = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::evaluatePlacementRequestForQuote(
+            $session,
+            $quote,
+            null,
+            null
+        );
+
+        $this->assertSame('allow', $result['action']);
+        $this->assertSame(1, $session->getData(Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::SESSION_PLACEMENT_FLAG));
+    }
+
+    public function testEvaluateReturnsSuccessExistingForOwnedInactiveQuote()
+    {
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'is_active' => 0,
+            'customer_id' => 1,
+        ));
+        $order = new Mage_Sales_Model_Order(array(
+            'entity_id' => 100,
+            'quote_id' => 5,
+            'increment_id' => '100000099',
+            'customer_id' => 1,
+        ));
+        $session = new Mage_Checkout_Model_Session(array('quote' => $quote));
+
+        $orderModel = new class($order) extends Varien_Object {
+            private $order;
+
+            public function __construct($order)
+            {
+                $this->order = $order;
+            }
+
+            public function loadByAttribute($code, $value)
+            {
+                return $this->order;
+            }
+        };
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setModel('sales/order', $orderModel);
+
+        $result = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::evaluatePlacementRequestForQuote(
+            $session,
+            $quote
+        );
+
+        $this->assertSame('success_existing', $result['action']);
+        $this->assertSame($order, $result['order']);
+    }
+
+    public function testEvaluateBlocksSuccessExistingForForeignInactiveQuoteOrder()
+    {
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'is_active' => 0,
+            'customer_id' => 2,
+            'customer_email' => 'bob@example.com',
+        ));
+        $order = new Mage_Sales_Model_Order(array(
+            'entity_id' => 100,
+            'quote_id' => 99,
+            'increment_id' => '100000100',
+            'customer_id' => 1,
+            'customer_email_direct' => 'alice@example.com',
+        ));
+        $session = new Mage_Checkout_Model_Session(array('quote' => $quote));
+
+        $orderModel = new class($order) extends Varien_Object {
+            private $order;
+
+            public function __construct($order)
+            {
+                $this->order = $order;
+            }
+
+            public function loadByAttribute($code, $value)
+            {
+                return $this->order;
+            }
+        };
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setModel('sales/order', $orderModel);
+
+        $result = Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::evaluatePlacementRequestForQuote(
+            $session,
+            $quote
+        );
+
+        $this->assertSame('block', $result['action']);
+        $this->assertArrayHasKey('message', $result);
+    }
+
+    public function testEvaluateRejectsForeignWalletEpsOrderId()
+    {
+        $quote = new Mage_Sales_Model_Quote(array(
+            'entity_id' => 5,
+            'is_active' => 1,
+        ));
+        $session = new Mage_Checkout_Model_Session(array(
+            'quote' => $quote,
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::SESSION_WALLET_EPS_ORDER_ID => 'eps-mine',
+        ));
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton('checkout/session', $session);
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionCode(
+            Bold_CheckoutPaymentBooster_Service_Order_CheckoutSessionOwnership::EXCEPTION_QUOTE_ACCESS_DENIED
+        );
+
+        Bold_CheckoutPaymentBooster_Service_Order_PlacementGuard::evaluatePlacementRequestForQuote(
+            $session,
+            $quote,
+            'eps-theirs'
+        );
+    }
+}
+

--- a/tests/unit/RouterAuthorizeTest.php
+++ b/tests/unit/RouterAuthorizeTest.php
@@ -1,0 +1,281 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class RouterAuthorizeTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // verifyHmac — happy paths
+    // -------------------------------------------------------------------------
+
+    public function testVerifyHmacMatchesValidSignature()
+    {
+        $timestamp = 'Sun, 07 Jun 26 18:25:49 +0000';
+        $secret = 'testsec1';
+        $signatureHeader = 'keyId="X-HMAC",algorithm="hmac-sha256",headers="x-hmac-timestamp",signature="'
+            . base64_encode(hash_hmac('sha256', 'x-hmac-timestamp: ' . $timestamp, $secret, true))
+            . '"';
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                $secret,
+                $signatureHeader,
+                $timestamp
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // verifyHmac — failure paths
+    // -------------------------------------------------------------------------
+
+    public function testVerifyHmacFailsWithWrongSecret()
+    {
+        $timestamp = 'Sun, 07 Jun 26 18:25:49 +0000';
+        $goodSecret = 'testsec1';
+        $wrongSecret = 'wrongsec';
+        $signatureHeader = 'keyId="X-HMAC",algorithm="hmac-sha256",headers="x-hmac-timestamp",signature="'
+            . base64_encode(hash_hmac('sha256', 'x-hmac-timestamp: ' . $timestamp, $goodSecret, true))
+            . '"';
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                $wrongSecret,
+                $signatureHeader,
+                $timestamp
+            )
+        );
+    }
+
+    public function testVerifyHmacFailsWithTamperedSignature()
+    {
+        $timestamp = 'Sun, 07 Jun 26 18:25:49 +0000';
+        $secret = 'testsec1';
+        $tamperedHeader = 'keyId="X-HMAC",algorithm="hmac-sha256",headers="x-hmac-timestamp",signature="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="';
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                $secret,
+                $tamperedHeader,
+                $timestamp
+            )
+        );
+    }
+
+    public function testVerifyHmacFailsWithWrongTimestamp()
+    {
+        $goodTimestamp = 'Sun, 07 Jun 26 18:25:49 +0000';
+        $wrongTimestamp = 'Mon, 08 Jun 26 12:00:00 +0000';
+        $secret = 'testsec1';
+        $signatureHeader = 'keyId="X-HMAC",algorithm="hmac-sha256",headers="x-hmac-timestamp",signature="'
+            . base64_encode(hash_hmac('sha256', 'x-hmac-timestamp: ' . $goodTimestamp, $secret, true))
+            . '"';
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                $secret,
+                $signatureHeader,
+                $wrongTimestamp
+            )
+        );
+    }
+
+    public function testVerifyHmacFailsWhenTimestampMissing()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                'testsec1',
+                'signature="abc"',
+                null
+            )
+        );
+    }
+
+    public function testVerifyHmacFailsWhenSecretMissing()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                null,
+                'signature="abc"',
+                'Sun, 07 Jun 26 18:25:49 +0000'
+            )
+        );
+    }
+
+    public function testVerifyHmacFailsWhenSignatureHeaderMissing()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                'testsec1',
+                null,
+                'Sun, 07 Jun 26 18:25:49 +0000'
+            )
+        );
+    }
+
+    public function testVerifyHmacFailsWhenSignatureNotPresentInHeader()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                'testsec1',
+                'keyId="X-HMAC",algorithm="hmac-sha256"',
+                'Sun, 07 Jun 26 18:25:49 +0000'
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // buildBoldSignatureHeader + verifyHmac round-trip
+    // -------------------------------------------------------------------------
+
+    public function testBuildBoldSignatureHeaderMatchesVerifyHmac()
+    {
+        $timestamp = 'Sun, 07 Jun 26 18:25:49 +0000';
+        $secret = 'testsec1';
+        $signatureHeader = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::buildBoldSignatureHeader(
+            $secret,
+            $timestamp
+        );
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                $secret,
+                $signatureHeader,
+                $timestamp
+            )
+        );
+    }
+
+    public function testBuildBoldSignatureHeaderIsNotVerifiableWithDifferentSecret()
+    {
+        $timestamp = 'Sun, 07 Jun 26 18:25:49 +0000';
+        $signatureHeader = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::buildBoldSignatureHeader(
+            'correctSecret',
+            $timestamp
+        );
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::verifyHmac(
+                'wrongSecret',
+                $signatureHeader,
+                $timestamp
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // buildBoldTimestamp
+    // -------------------------------------------------------------------------
+
+    public function testBuildBoldTimestampReturnsUtcRfc1123Format()
+    {
+        $timestamp = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::buildBoldTimestamp();
+
+        // RFC 1123 short-year format: "Mon, 09 Jun 26 12:00:00 +0000"
+        $this->assertMatchesRegularExpression(
+            '/^\w{3}, \d{2} \w{3} \d{2} \d{2}:\d{2}:\d{2} \+0000$/',
+            $timestamp
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // getInboundHeader
+    // -------------------------------------------------------------------------
+
+    public function testGetInboundHeaderFallsBackToServerVariable()
+    {
+        $request = new Zend_Controller_Request_Http();
+        $_SERVER['HTTP_X_HMAC_TIMESTAMP'] = 'Sun, 07 Jun 26 18:25:49 +0000';
+
+        $this->assertSame(
+            'Sun, 07 Jun 26 18:25:49 +0000',
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::getInboundHeader(
+                $request,
+                'X-HMAC-Timestamp'
+            )
+        );
+
+        unset($_SERVER['HTTP_X_HMAC_TIMESTAMP']);
+    }
+
+    public function testGetInboundHeaderPrefersGetHeaderOverServerVariable()
+    {
+        $request = new Zend_Controller_Request_Http();
+        $request->setHeader('X-HMAC-Timestamp', 'from-get-header');
+        $_SERVER['HTTP_X_HMAC_TIMESTAMP'] = 'from-server';
+
+        $this->assertSame(
+            'from-get-header',
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::getInboundHeader(
+                $request,
+                'X-HMAC-Timestamp'
+            )
+        );
+
+        unset($_SERVER['HTTP_X_HMAC_TIMESTAMP']);
+    }
+
+    public function testGetInboundHeaderReturnsNullWhenAbsent()
+    {
+        $request = new Zend_Controller_Request_Http();
+
+        $this->assertNull(
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::getInboundHeader(
+                $request,
+                'X-HMAC-Timestamp'
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // secretFingerprint
+    // -------------------------------------------------------------------------
+
+    public function testSecretFingerprintReturnsStablePrefix()
+    {
+        $this->assertSame(
+            substr(hash('sha256', 'secret'), 0, 8),
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint('secret')
+        );
+    }
+
+    public function testSecretFingerprintReturnsEightHexCharacters()
+    {
+        $fp = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint('anyvalue');
+
+        $this->assertSame(8, strlen($fp));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{8}$/', $fp);
+    }
+
+    public function testSecretFingerprintReturnsZerosForNull()
+    {
+        $this->assertSame(
+            '00000000',
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint(null)
+        );
+    }
+
+    public function testSecretFingerprintReturnsZerosForEmptyString()
+    {
+        $this->assertSame(
+            '00000000',
+            Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint('')
+        );
+    }
+
+    public function testSecretFingerprintIsDeterministicForSameInput()
+    {
+        $fp1 = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint('stableSecret');
+        $fp2 = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint('stableSecret');
+
+        $this->assertSame($fp1, $fp2);
+    }
+
+    public function testSecretFingerprintDiffersForDifferentSecrets()
+    {
+        $fp1 = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint('secretA');
+        $fp2 = Bold_CheckoutPaymentBooster_Service_Inbound_Auth::secretFingerprint('secretB');
+
+        $this->assertNotSame($fp1, $fp2);
+    }
+}

--- a/tests/unit/RsaConnectTest.php
+++ b/tests/unit/RsaConnectTest.php
@@ -1,0 +1,481 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class RsaConnectTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::reset();
+        Bold_CheckoutPaymentBooster_Test_Stub_BoldClient::reset();
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            'website_default_store_1',
+            new Mage_Core_Model_Store('https://www.example.com/')
+        );
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            'core/resource',
+            new Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Resource()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // getRestCallbackUrl
+    // -------------------------------------------------------------------------
+
+    public function testGetRestCallbackUrlUsesWebsiteDefaultStore()
+    {
+        $url = Bold_CheckoutPaymentBooster_Service_Rsa_Connect::getRestCallbackUrl(1);
+
+        $this->assertSame('https://www.example.com/rest/V1', $url);
+    }
+
+    // -------------------------------------------------------------------------
+    // assertShopIdPresent
+    // -------------------------------------------------------------------------
+
+    public function testAssertShopIdPresentThrowsWhenMissing()
+    {
+        $config = new Bold_CheckoutPaymentBooster_Test_Stub_Config();
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            $config
+        );
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionMessage('Bold shop ID is missing');
+
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::assertShopIdPresent(1);
+    }
+
+    public function testAssertShopIdPresentDoesNotThrowWhenPresent()
+    {
+        $config = new Bold_CheckoutPaymentBooster_Test_Stub_Config();
+        $config->setValue('shop_id', 'abc123');
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            $config
+        );
+
+        $this->expectNotToPerformAssertions();
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::assertShopIdPresent(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // isRegistrationSuccess
+    // -------------------------------------------------------------------------
+
+    public function testIsRegistrationSuccessReturnsTrueWithoutErrors()
+    {
+        $result = (object)array('data' => (object)array('ok' => true));
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRegistrationSuccess($result)
+        );
+    }
+
+    public function testIsRegistrationSuccessReturnsFalseWithErrorsArray()
+    {
+        $result = (object)array(
+            'errors' => array((object)array('message' => 'failed')),
+        );
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRegistrationSuccess($result)
+        );
+    }
+
+    public function testIsRegistrationSuccessReturnsFalseWithTopLevelErrorKey()
+    {
+        $result = (object)array('error' => 'Unauthorized');
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRegistrationSuccess($result)
+        );
+    }
+
+    public function testIsRegistrationSuccessReturnsFalseForNull()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRegistrationSuccess(null)
+        );
+    }
+
+    public function testIsRegistrationSuccessReturnsFalseForNonObject()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRegistrationSuccess('error string')
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // isRsaNotConfigured
+    // -------------------------------------------------------------------------
+
+    public function testIsRsaNotConfiguredDetectsErrorCode02_89WithObject()
+    {
+        $result = (object)array(
+            'errors' => array((object)array('code' => '02-89', 'message' => 'Remote State Authority not configured')),
+        );
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRsaNotConfigured($result)
+        );
+    }
+
+    public function testIsRsaNotConfiguredDetectsErrorCode02_89WithArrayError()
+    {
+        $result = (object)array(
+            'errors' => array(array('code' => '02-89', 'message' => 'RSA not configured')),
+        );
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRsaNotConfigured($result)
+        );
+    }
+
+    public function testIsRsaNotConfiguredReturnsFalseForOtherErrorCode()
+    {
+        $result = (object)array(
+            'errors' => array((object)array('code' => '02-02', 'message' => 'something else')),
+        );
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRsaNotConfigured($result)
+        );
+    }
+
+    public function testIsRsaNotConfiguredReturnsFalseForNull()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRsaNotConfigured(null)
+        );
+    }
+
+    public function testIsRsaNotConfiguredReturnsFalseForEmptyErrors()
+    {
+        $result = (object)array('errors' => array());
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isRsaNotConfigured($result)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // getRegistrationErrorMessage
+    // -------------------------------------------------------------------------
+
+    public function testGetRegistrationErrorMessageExtractsFromErrorsArray()
+    {
+        $result = (object)array(
+            'errors' => array((object)array('code' => '02-99', 'message' => 'Shop not found')),
+        );
+
+        $this->assertSame(
+            'Shop not found',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::getRegistrationErrorMessage($result)
+        );
+    }
+
+    public function testGetRegistrationErrorMessageExtractsErrorDescription()
+    {
+        $result = (object)array('error_description' => 'Invalid API token');
+
+        $this->assertSame(
+            'Invalid API token',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::getRegistrationErrorMessage($result)
+        );
+    }
+
+    public function testGetRegistrationErrorMessageExtractsNestedErrorMessage()
+    {
+        $result = (object)array('error' => (object)array('message' => 'Nested error detail'));
+
+        $this->assertSame(
+            'Nested error detail',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::getRegistrationErrorMessage($result)
+        );
+    }
+
+    public function testGetRegistrationErrorMessageReturnsEmptyForNull()
+    {
+        $this->assertSame(
+            '',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::getRegistrationErrorMessage(null)
+        );
+    }
+
+    public function testGetRegistrationErrorMessageReturnsEmptyForNonObject()
+    {
+        $this->assertSame(
+            '',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::getRegistrationErrorMessage('raw string')
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // isCheckSharedSuccess
+    // -------------------------------------------------------------------------
+
+    public function testIsCheckSharedSuccessAcceptsIntegerOne()
+    {
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isCheckSharedSuccess(
+                (object)array('data' => 1)
+            )
+        );
+    }
+
+    public function testIsCheckSharedSuccessAcceptsStringOne()
+    {
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isCheckSharedSuccess(
+                (object)array('data' => '1')
+            )
+        );
+    }
+
+    public function testIsCheckSharedSuccessAcceptsBooleanTrue()
+    {
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isCheckSharedSuccess(
+                (object)array('data' => true)
+            )
+        );
+    }
+
+    public function testIsCheckSharedSuccessRejectsIntegerZero()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isCheckSharedSuccess(
+                (object)array('data' => 0)
+            )
+        );
+    }
+
+    public function testIsCheckSharedSuccessRejectsBooleanFalse()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isCheckSharedSuccess(
+                (object)array('data' => false)
+            )
+        );
+    }
+
+    public function testIsCheckSharedSuccessRejectsMissingData()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isCheckSharedSuccess(
+                (object)array('errors' => array())
+            )
+        );
+    }
+
+    public function testIsCheckSharedSuccessRejectsNull()
+    {
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::isCheckSharedSuccess(null)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // getVerificationFailureMessage
+    // -------------------------------------------------------------------------
+
+    public function testGetVerificationFailureMessageIncludesRollbackNoteWhenPreviousSecretExists()
+    {
+        $message = Bold_CheckoutPaymentBooster_Service_Rsa_Connect::getVerificationFailureMessage(true);
+
+        $this->assertStringContainsString('restored on Bold', $message);
+        $this->assertStringContainsString('Bold could not confirm the new shared secret', $message);
+        $this->assertStringContainsString('Rotate Shared Key', $message);
+    }
+
+    public function testGetVerificationFailureMessageNoPreviousSecretMentionsRotateSharedKey()
+    {
+        $message = Bold_CheckoutPaymentBooster_Service_Rsa_Connect::getVerificationFailureMessage(false);
+
+        $this->assertStringContainsString('Bold could not confirm the new shared secret', $message);
+        $this->assertStringContainsString('Rotate Shared Key', $message);
+        $this->assertStringNotContainsString('restored on Bold', $message);
+    }
+
+    // -------------------------------------------------------------------------
+    // verifySharedSecretWithBoldCheckShared
+    // -------------------------------------------------------------------------
+
+    public function testVerifySharedSecretWithBoldCheckSharedReturnsTrueWhenBoldConfirms()
+    {
+        Bold_CheckoutPaymentBooster_Test_Stub_BoldClient::setResponse(
+            'POST',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::CHECK_SHARED_URL,
+            (object)array('data' => 1)
+        );
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::verifySharedSecretWithBoldCheckShared(
+                1,
+                'newsecret',
+                'https://www.example.com/rest/V1'
+            )
+        );
+    }
+
+    public function testVerifySharedSecretWithBoldCheckSharedReturnsFalseWhenBoldRejects()
+    {
+        Bold_CheckoutPaymentBooster_Test_Stub_BoldClient::setResponse(
+            'POST',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::CHECK_SHARED_URL,
+            (object)array('data' => 0)
+        );
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::verifySharedSecretWithBoldCheckShared(
+                1,
+                'newsecret',
+                'https://www.example.com/rest/V1'
+            )
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // rotation lock
+    // -------------------------------------------------------------------------
+
+    public function testAcquireRotationLockReturnsFalseWhenRegistryLockHeld()
+    {
+        Mage::register('bold_checkout_rsa_rotating_1', true);
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::acquireRotationLock(1)
+        );
+    }
+
+    public function testAcquireAndReleaseRotationLock()
+    {
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::acquireRotationLock(1)
+        );
+
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::releaseRotationLock(1);
+
+        $this->assertNull(Mage::registry('bold_checkout_rsa_rotating_1'));
+    }
+
+    // -------------------------------------------------------------------------
+    // registerRsaConfig — error paths
+    // -------------------------------------------------------------------------
+
+    public function testRegisterRsaConfigThrowsWhenShopIdMissing()
+    {
+        $config = new Bold_CheckoutPaymentBooster_Test_Stub_Config();
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            $config
+        );
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionMessage('Bold shop ID is missing');
+
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::registerRsaConfig(1, true);
+    }
+
+    public function testRegisterRsaConfigThrowsWhenBoldReturnsPermanentError()
+    {
+        $config = new Bold_CheckoutPaymentBooster_Test_Stub_Config();
+        $config->setValue('shop_id', 'shop_abc123');
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            $config
+        );
+
+        $errorResponse = (object)array(
+            'errors' => array((object)array('code' => '99-99', 'message' => 'Permanent failure')),
+        );
+        Bold_CheckoutPaymentBooster_Test_Stub_BoldClient::setResponse(
+            'PATCH',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::URL,
+            $errorResponse
+        );
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionMessage('RSA registration failed');
+
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::registerRsaConfig(1, true);
+    }
+
+    public function testRegisterRsaConfigThrowsWhenCheckSharedFails()
+    {
+        $config = new Bold_CheckoutPaymentBooster_Test_Stub_Config();
+        $config->setValue('shop_id', 'shop_abc123');
+        $config->setValue('shared_secret', 'oldSecret');
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            $config
+        );
+
+        Bold_CheckoutPaymentBooster_Test_Stub_BoldClient::setResponse(
+            'POST',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::CHECK_SHARED_URL,
+            (object)array('data' => 0)
+        );
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionMessage('Bold could not confirm the new shared secret');
+
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::registerRsaConfig(1, true);
+    }
+
+    public function testRegisterRsaConfigDoesNotPersistSecretUntilCheckSharedPasses()
+    {
+        $config = new Bold_CheckoutPaymentBooster_Test_Stub_Config();
+        $config->setValue('shop_id', 'shop_abc123');
+        $config->setValue('shared_secret', 'oldSecret');
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            $config
+        );
+
+        Bold_CheckoutPaymentBooster_Test_Stub_BoldClient::setResponse(
+            'POST',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::CHECK_SHARED_URL,
+            (object)array('data' => 1)
+        );
+
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::registerRsaConfig(1, true);
+
+        $this->assertNotSame('oldSecret', $config->getSharedSecret(1));
+        $this->assertNotEmpty($config->getSharedSecret(1));
+    }
+
+    public function testRegisterRsaConfigFallsBackToPostWhenPatchReturns0289()
+    {
+        $config = new Bold_CheckoutPaymentBooster_Test_Stub_Config();
+        $config->setValue('shop_id', 'shop_abc123');
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            $config
+        );
+
+        $notConfiguredResponse = (object)array(
+            'errors' => array((object)array('code' => '02-89', 'message' => 'RSA not configured')),
+        );
+        Bold_CheckoutPaymentBooster_Test_Stub_BoldClient::setResponse(
+            'PATCH',
+            Bold_CheckoutPaymentBooster_Service_Rsa_Connect::URL,
+            $notConfiguredResponse
+        );
+
+        $this->expectNotToPerformAssertions();
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::registerRsaConfig(1, true);
+    }
+
+    public function testRegisterRsaConfigThrowsWhenRotationAlreadyInProgress()
+    {
+        Mage::register('bold_checkout_rsa_rotating_1', true);
+
+        $this->expectException(Mage_Core_Exception::class);
+        $this->expectExceptionMessage('RSA rotation is already in progress');
+
+        Bold_CheckoutPaymentBooster_Service_Rsa_Connect::registerRsaConfig(1, true);
+    }
+}

--- a/tests/unit/SavePipelineTest.php
+++ b/tests/unit/SavePipelineTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class SavePipelineTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::reset();
+        $config = new Bold_CheckoutPaymentBooster_Test_Stub_Config();
+        Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+            Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+            $config
+        );
+    }
+
+    public function testShouldRotateRsaWhenForceFlagSet()
+    {
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::shouldRotateRsa(1, true)
+        );
+    }
+
+    public function testShouldRotateRsaWhenSharedSecretMissing()
+    {
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::shouldRotateRsa(1, false)
+        );
+    }
+
+    public function testShouldRotateRsaWhenApiTokenChangedRegistryFlagSet()
+    {
+        /** @var Bold_CheckoutPaymentBooster_Test_Stub_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        $config->setValue('shared_secret', 'existing');
+        Mage::register('bold_checkout_api_token_changed_1', true);
+
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::shouldRotateRsa(1, false)
+        );
+    }
+
+    public function testShouldNotRotateRsaWhenNothingChanged()
+    {
+        /** @var Bold_CheckoutPaymentBooster_Test_Stub_Config $config */
+        $config = Mage::getSingleton(Bold_CheckoutPaymentBooster_Model_Config::RESOURCE);
+        $config->setValue('shared_secret', 'existing');
+        $config->setValue('api_token', 'token-value');
+        $config->setValue('api_token_fingerprint', hash('sha256', 'token-value'));
+
+        $this->assertFalse(
+            Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::shouldRotateRsa(1, false)
+        );
+    }
+
+    public function testHostsMatchIgnoresWwwDifference()
+    {
+        $this->assertTrue(
+            Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::hostsMatch(
+                'www.example.com',
+                'example.com'
+            )
+        );
+    }
+
+    public function testNormalizeHostStripsSchemeAndPath()
+    {
+        $this->assertSame(
+            'www.example.com',
+            Bold_CheckoutPaymentBooster_Service_Config_SavePipeline::normalizeHost(
+                'https://www.example.com/store/'
+            )
+        );
+    }
+}

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,0 +1,19 @@
+<?php
+
+error_reporting(E_ALL);
+ini_set('display_errors', '1');
+
+require_once __DIR__ . '/stubs/MagentoStubs.php';
+
+$moduleRoot = dirname(dirname(__DIR__));
+require_once $moduleRoot . '/Service/Order/CheckoutSessionOwnership.php';
+require_once $moduleRoot . '/Service/Order/PlacementGuard.php';
+require_once $moduleRoot . '/Service/Rsa/Connect.php';
+require_once $moduleRoot . '/Service/Config/SavePipeline.php';
+require_once $moduleRoot . '/Service/Inbound/Auth.php';
+
+Bold_CheckoutPaymentBooster_Test_Stub_Mage::reset();
+Bold_CheckoutPaymentBooster_Test_Stub_Mage::setSingleton(
+    Bold_CheckoutPaymentBooster_Model_Config::RESOURCE,
+    new Bold_CheckoutPaymentBooster_Model_Config()
+);

--- a/tests/unit/composer.json
+++ b/tests/unit/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "bold/checkout-payment-booster-unit-tests",
+    "require-dev": {
+        "phpunit/phpunit": "^9.6"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/tests/unit/composer.lock
+++ b/tests/unit/composer.lock
@@ -1,0 +1,1818 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "eaf427e91c04d06abdb542687ebc4d5d",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/tests/unit/phpunit.xml.dist
+++ b/tests/unit/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    bootstrap="bootstrap.php"
+    colors="true"
+    failOnRisky="true"
+    failOnWarning="true"
+>
+    <testsuites>
+        <testsuite name="Bold CheckoutPaymentBooster Unit">
+            <directory>.</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">../../Service/Order</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/unit/stubs/MagentoStubs.php
+++ b/tests/unit/stubs/MagentoStubs.php
@@ -1,0 +1,573 @@
+<?php
+
+class Varien_Object
+{
+    protected $_data = array();
+
+    public function __construct($data = array())
+    {
+        $this->_data = $data;
+    }
+
+    public function getId()
+    {
+        return isset($this->_data['entity_id']) ? $this->_data['entity_id'] : null;
+    }
+
+    public function getData($key = '', $index = null)
+    {
+        if ($key === '') {
+            return $this->_data;
+        }
+
+        return isset($this->_data[$key]) ? $this->_data[$key] : null;
+    }
+
+    public function setData($key, $value = null)
+    {
+        if (is_array($key)) {
+            $this->_data = array_merge($this->_data, $key);
+        } else {
+            $this->_data[$key] = $value;
+        }
+
+        return $this;
+    }
+
+    public function unsetData($key = null)
+    {
+        if ($key === null) {
+            $this->_data = array();
+        } else {
+            unset($this->_data[$key]);
+        }
+
+        return $this;
+    }
+
+    public function getQuoteId()
+    {
+        return $this->getData('quote_id');
+    }
+
+    public function getCustomerId()
+    {
+        return $this->getData('customer_id');
+    }
+
+    public function getCustomerEmail()
+    {
+        return $this->getData('customer_email');
+    }
+
+    public function getIsActive()
+    {
+        return $this->getData('is_active');
+    }
+
+    public function getIncrementId()
+    {
+        return $this->getData('increment_id');
+    }
+
+    public function getBillingAddress()
+    {
+        return $this->getData('billing_address');
+    }
+
+    public function getQuote()
+    {
+        return $this->getData('quote');
+    }
+
+    public function getPayment()
+    {
+        return $this->getData('payment');
+    }
+
+    public function getStore()
+    {
+        return $this->getData('store');
+    }
+}
+
+class Mage_Sales_Model_Order extends Varien_Object
+{
+    public function getCustomerEmail()
+    {
+        $email = parent::getCustomerEmail();
+        if ($email) {
+            return $email;
+        }
+
+        return $this->getData('customer_email_direct');
+    }
+}
+
+class Mage_Sales_Model_Quote extends Varien_Object
+{
+    public function load($id)
+    {
+        $quote = Bold_CheckoutPaymentBooster_Test_Stub_Mage::getQuoteById($id);
+        if ($quote) {
+            $this->_data = $quote->getData();
+        }
+
+        return $this;
+    }
+}
+
+class Mage_Checkout_Model_Session extends Varien_Object
+{
+    public function getQuote()
+    {
+        return $this->getData('quote');
+    }
+
+    public function getQuoteId()
+    {
+        return $this->getData('quote_id');
+    }
+}
+
+class Mage_Core_Helper_Abstract
+{
+    public function __call($name, $arguments)
+    {
+        if ($name === '__') {
+            return $arguments[0];
+        }
+
+        return null;
+    }
+}
+
+class Mage_Core_Exception extends Exception
+{
+}
+
+class Bold_CheckoutPaymentBooster_Model_Config
+{
+    const RESOURCE = 'bold_checkout_payment_booster/config';
+    const LOG_FILE_NAME = 'bold_checkout_payment_booster.log';
+
+    public function isLogEnabled($websiteId)
+    {
+        return true;
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Model_Store
+{
+    const URL_TYPE_WEB = 'web';
+    const URL_TYPE_LINK = 'link';
+
+    private $baseUrl;
+
+    public function __construct($baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+    }
+
+    public function getBaseUrl($type, $secure = null)
+    {
+        return $this->baseUrl;
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage_Website
+{
+    private $websiteId;
+
+    public function __construct($websiteId)
+    {
+        $this->websiteId = $websiteId;
+    }
+
+    public function getId()
+    {
+        return $this->websiteId;
+    }
+
+    public function getDefaultStore()
+    {
+        $store = Bold_CheckoutPaymentBooster_Test_Stub_Mage::getSingleton(
+            'website_default_store_' . $this->websiteId
+        );
+        if (!$store) {
+            throw new RuntimeException('Default store not configured for website ' . $this->websiteId);
+        }
+
+        return $store;
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage_App
+{
+    public function getWebsite($websiteId)
+    {
+        return new Bold_CheckoutPaymentBooster_Test_Stub_Mage_Website($websiteId);
+    }
+
+    public function getStore()
+    {
+        return new Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Model_Store_Website('https://example.com/');
+    }
+
+    public function getRequest()
+    {
+        return new Bold_CheckoutPaymentBooster_Test_Stub_Mage_Request();
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Model_Store_Website extends Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Model_Store
+{
+    public function getWebsiteId()
+    {
+        return 1;
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage_Request
+{
+    public function getRequestUri()
+    {
+        return '/checkout/onepage/saveOrder';
+    }
+
+    public function getParam($key)
+    {
+        return null;
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Config
+{
+    private $values = array();
+
+    public function setValue($path, $value)
+    {
+        $this->values[$path] = $value;
+    }
+
+    public function getShopId($websiteId)
+    {
+        return isset($this->values['shop_id']) ? $this->values['shop_id'] : null;
+    }
+
+    public function getSharedSecret($websiteId)
+    {
+        return isset($this->values['shared_secret']) ? $this->values['shared_secret'] : null;
+    }
+
+    public function getApiTokenFingerprint($websiteId)
+    {
+        return isset($this->values['api_token_fingerprint']) ? $this->values['api_token_fingerprint'] : null;
+    }
+
+    public function buildApiTokenFingerprint($websiteId)
+    {
+        if (empty($this->values['api_token'])) {
+            return null;
+        }
+
+        return hash('sha256', $this->values['api_token']);
+    }
+
+    public function setSharedSecret($secret, $websiteId)
+    {
+        $this->values['shared_secret'] = $secret;
+    }
+
+    public function getShopDomain($websiteId)
+    {
+        return isset($this->values['shop_domain']) ? $this->values['shop_domain'] : '';
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_BoldClient
+{
+    /** @var array<string, stdClass|null> Map of 'METHOD:url' → response object */
+    public static $responses = array();
+
+    public static function reset()
+    {
+        self::$responses = array();
+    }
+
+    public static function setResponse($method, $url, $response)
+    {
+        self::$responses[strtoupper($method) . ':' . $url] = $response;
+    }
+
+    public static function patch($url, $websiteId, $body)
+    {
+        return self::getResponse('PATCH', $url);
+    }
+
+    public static function post($url, $websiteId, $body)
+    {
+        return self::getResponse('POST', $url);
+    }
+
+    public static function get($url, $websiteId)
+    {
+        return self::getResponse('GET', $url);
+    }
+
+    private static function getResponse($method, $url)
+    {
+        $key = $method . ':' . $url;
+        if (array_key_exists($key, self::$responses)) {
+            return self::$responses[$key];
+        }
+
+        if (strpos($url, 'checkShared') !== false) {
+            return (object)array('data' => 1);
+        }
+
+        return (object)array('data' => (object)array('ok' => true));
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage_Config
+{
+    public function deleteConfig($path, $scope, $scopeId) {}
+    public function cleanCache() {}
+}
+
+if (!class_exists('Bold_CheckoutPaymentBooster_Service_BoldClient', false)) {
+    class Bold_CheckoutPaymentBooster_Service_BoldClient extends Bold_CheckoutPaymentBooster_Test_Stub_BoldClient {}
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Request
+{
+    private $headers = array();
+
+    public function setHeader($name, $value)
+    {
+        $this->headers[$name] = $value;
+    }
+
+    public function getHeader($name)
+    {
+        return isset($this->headers[$name]) ? $this->headers[$name] : false;
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Model_Payment_Bold
+{
+    const CODE = 'bold';
+}
+
+class Bold_CheckoutPaymentBooster_Model_Payment_Fastlane
+{
+    const CODE = 'bold_fastlane';
+}
+
+class Bold_CheckoutPaymentBooster_Service_Bold
+{
+    public static function getPublicOrderId()
+    {
+        return Bold_CheckoutPaymentBooster_Test_Stub_Mage::$publicOrderId;
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Resource
+{
+    public function getConnection($name)
+    {
+        return new Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Resource_Connection();
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Resource_Connection
+{
+    public function fetchOne($sql, $bind = array())
+    {
+        if (stripos($sql, 'GET_LOCK') !== false) {
+            return '1';
+        }
+
+        return null;
+    }
+
+    public function query($sql, $bind = array())
+    {
+        return null;
+    }
+}
+
+class Bold_CheckoutPaymentBooster_Test_Stub_Mage
+{
+    public static $singletons = array();
+
+    public static $models = array();
+
+    public static $quotesById = array();
+
+    public static $publicOrderId = null;
+
+    public static $logMessages = array();
+
+    private static $registry = array();
+
+    public static function reset()
+    {
+        self::$singletons = array();
+        self::$models = array();
+        self::$quotesById = array();
+        self::$publicOrderId = null;
+        self::$logMessages = array();
+        self::$registry = array();
+    }
+
+    public static function setSingleton($key, $object)
+    {
+        self::$singletons[$key] = $object;
+    }
+
+    public static function getSingleton($key)
+    {
+        return isset(self::$singletons[$key]) ? self::$singletons[$key] : null;
+    }
+
+    public static function setModel($name, $object)
+    {
+        self::$models[$name] = $object;
+    }
+
+    public static function getModel($name)
+    {
+        if (isset(self::$models[$name])) {
+            return self::$models[$name];
+        }
+
+        if ($name === 'sales/quote') {
+            return new Mage_Sales_Model_Quote();
+        }
+
+        return new Varien_Object();
+    }
+
+    public static function setQuoteById($id, Mage_Sales_Model_Quote $quote)
+    {
+        self::$quotesById[$id] = $quote;
+    }
+
+    public static function getQuoteById($id)
+    {
+        return isset(self::$quotesById[$id]) ? self::$quotesById[$id] : null;
+    }
+
+    public static function register($key, $value)
+    {
+        self::$registry[$key] = $value;
+    }
+
+    public static function registry($key)
+    {
+        return isset(self::$registry[$key]) ? self::$registry[$key] : null;
+    }
+
+    public static function unregister($key)
+    {
+        unset(self::$registry[$key]);
+    }
+
+    public static function app()
+    {
+        return new Bold_CheckoutPaymentBooster_Test_Stub_Mage_App();
+    }
+
+    public static function throwException($message)
+    {
+        throw new Mage_Core_Exception($message);
+    }
+}
+
+if (!class_exists('Mage', false)) {
+    class Mage
+    {
+        public static function helper($name)
+        {
+            return new Mage_Core_Helper_Abstract();
+        }
+
+        public static function getSingleton($key)
+        {
+            return Bold_CheckoutPaymentBooster_Test_Stub_Mage::getSingleton($key);
+        }
+
+        public static function getModel($name)
+        {
+            return Bold_CheckoutPaymentBooster_Test_Stub_Mage::getModel($name);
+        }
+
+        public static function log($message, $level = null, $file = null, $forceLog = false)
+        {
+            Bold_CheckoutPaymentBooster_Test_Stub_Mage::$logMessages[] = array(
+                'message' => $message,
+                'file' => $file,
+            );
+        }
+
+        public static function app()
+        {
+            return Bold_CheckoutPaymentBooster_Test_Stub_Mage::app();
+        }
+
+        public static function register($key, $value, $graceful = false)
+        {
+            Bold_CheckoutPaymentBooster_Test_Stub_Mage::register($key, $value);
+        }
+
+        public static function registry($key)
+        {
+            return Bold_CheckoutPaymentBooster_Test_Stub_Mage::registry($key);
+        }
+
+        public static function unregister($key)
+        {
+            Bold_CheckoutPaymentBooster_Test_Stub_Mage::unregister($key);
+        }
+
+        public static function throwException($message)
+        {
+            Bold_CheckoutPaymentBooster_Test_Stub_Mage::throwException($message);
+        }
+
+        public static function getConfig()
+        {
+            return new Bold_CheckoutPaymentBooster_Test_Stub_Mage_Config();
+        }
+
+        public static function logException($exception) {}
+    }
+}
+
+if (!class_exists('Mage_Core_Model_Store', false)) {
+    class Mage_Core_Model_Store extends Bold_CheckoutPaymentBooster_Test_Stub_Mage_Core_Model_Store
+    {
+    }
+}
+
+if (!class_exists('Zend_Controller_Request_Http', false)) {
+    class Zend_Controller_Request_Http extends Bold_CheckoutPaymentBooster_Test_Stub_Request
+    {
+    }
+}
+
+if (!class_exists('Zend_Log', false)) {
+    class Zend_Log
+    {
+        const EMERG  = 0;
+        const ALERT  = 1;
+        const CRIT   = 2;
+        const ERR    = 3;
+        const WARN   = 4;
+        const NOTICE = 5;
+        const INFO   = 6;
+        const DEBUG  = 7;
+    }
+}


### PR DESCRIPTION
Fixes fragile RSA shared-secret registration on Magento 1 Payment Booster. Replaces four independent config observers with a single ordered SavePipeline, stops accidental secret rotation on routine admin saves, and adds an explicit Rotate Shared Key action for when inbound webhooks fail auth.
Resolves secret drift between Magento and Bold Checkout that broke HMAC verification on inbound payment webhooks.

Because M1 observers are separate callbacks with no shared error handling, a partial failure in one step did not stop the others. In production this produced:
- Accidental secret rotation — saving Fastlane styles or Express Pay toggles regenerated the shared secret and pushed it to Bold.
- Secret drift — old flow used DELETE then POST on rsa_config. If POST failed after DELETE, Bold had no RSA config while Magento had already saved a new local secret.
- Wrong callback URL — RSA used Mage::app()->getStore() (admin session store), not the website being configured, so multi-store setups could register the wrong rest/V1 URL.
- RSA before shop_id — RSA could run when shop_id was still empty, producing broken API paths like checkout/shop//rsa_config.
- No explicit rotation — admins had no safe “rotate only when needed” action; routine saves were the only trigger.
- Inbound payment webhooks are HMAC-signed with this shared secret. When Magento and Bold Checkout disagree on the value, webhooks fail with matched=NO and orders do not complete.

Ticket: CHK-9611